### PR TITLE
Fix buffer-overrun in larson.cpp

### DIFF
--- a/benchmarks/larson/larson.cpp
+++ b/benchmarks/larson/larson.cpp
@@ -403,7 +403,7 @@ void runloops(long sleep_cnt, int num_chunks )
 //#ifdef _MT
 void runthreads(long sleep_cnt, int min_threads, int max_threads, int chperthread, int num_rounds)
 {
-  thread_data  de_area[MAX_THREADS] ;
+  thread_data *de_area = new thread_data[max_threads] ;
   thread_data *pdea;
   int           nperthread ;
   int           sum_threads ;
@@ -534,6 +534,7 @@ void runthreads(long sleep_cnt, int min_threads, int max_threads, int chperthrea
       printf ("Done sleeping...\n");
 
     }
+  delete [] de_area;
 }
 
 


### PR DESCRIPTION
Larson has the following problem:
 In the first line of runthreads(), de_area[] is defined to be an array of 100 thread_data items (MAX_THREADS is defined to be 100)
 However, de_area[i] is written to, where i ranges from 0 to num_threads, and num_threads could be larger than 100 in this case.
 So the initialization is writing off the end of the array.

Fix the problem by making allocating de_area with new.
