### PR TITLE
Changed git clone to git submodule update

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ all:
 	@echo "*****"
 	@echo "This Makefile is for Windows only. For other systems, use gmake."
 	@echo "*****"
-	git clone https://github.com/emeryberger/Heap-Layers
+	git submodule update --init --checkout --recursive
 	cl $(WIN_INCLUDES) $(WIN_DEFINES) $(WIN_FLAGS) "source\libhoard.cpp" "Heap-Layers\wrappers\winwrapper.cpp" "source\wintls.cpp" /GL /link /DLL /subsystem:console /OUT:libhoard.dll
 	cl $(WIN_INCLUDES) $(WIN_DEFINES) $(WIN_FLAGS) /c "source\uselibhoard.cpp"
 


### PR DESCRIPTION
Fixes repeating error when running nmake because it used clone.
The update command allows it to work even if the caller just does "git clone url" & "nmake".