### PR TITLE
WIP: hacky performance improvements around inlining

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -1,7 +1,7 @@
 # Commands to compile Hoard for various targets.
 # Run make (with no arguments) to see the complete target list.
 
-CPPFLAGS = -std=c++14 -O3 -DNDEBUG -ffast-math -fno-builtin-malloc -Wall -Wextra -Wshadow -Wconversion -Wuninitialized
+CPPFLAGS = -std=c++14 -flto -ftls-model=initial-exec -O3 -DNDEBUG -ffast-math -fno-builtin-malloc -Wall -Wextra -Wshadow -Wconversion -Wuninitialized
 #CPPFLAGS = -std=c++14 -g -O0 -ffast-math -fno-builtin-malloc -Wall -Wextra -Wshadow -Wconversion -Wuninitialized
 CXX = clang++
 
@@ -62,7 +62,7 @@ help:
 MAIN_SRC  = source/libhoard.cpp
 UNIX_SRC  = $(MAIN_SRC) source/unixtls.cpp
 SUNW_SRC  = $(UNIX_SRC) Heap-Layers/wrappers/wrapper.cpp
-GNU_SRC   = $(UNIX_SRC) Heap-Layers/wrappers/gnuwrapper.cpp
+GNU_SRC   = $(UNIX_SRC)
 MACOS_SRC = $(MAIN_SRC) Heap-Layers/wrappers/macwrapper.cpp source/mactls.cpp
 
 #

--- a/src/source/libhoard.cpp
+++ b/src/source/libhoard.cpp
@@ -108,7 +108,7 @@ extern bool isCustomHeapInitialized();
 
 extern "C" {
 
-  void * xxmalloc (size_t sz) {
+	void * __attribute__((always_inline)) xxmalloc (size_t sz) {
     if (isCustomHeapInitialized()) {
       void * ptr = getCustomHeap()->malloc (sz);
       if (ptr == nullptr) {
@@ -136,7 +136,7 @@ extern "C" {
     return ptr;
   }
 
-  void xxfree (void * ptr) {
+  void __attribute__((always_inline)) xxfree (void * ptr) {
     getCustomHeap()->free (ptr);
   }
 
@@ -153,3 +153,5 @@ extern "C" {
   }
 
 } // namespace Hoard
+
+#include "Heap-Layers/wrappers/gnuwrapper.cpp"


### PR DESCRIPTION
in addition, I added 3 always inline attributes in Heap-Layers:
```diff
diff --git a/wrappers/wrapper.cpp b/wrappers/wrapper.cpp
index 18b2a88..f0240a1 100644
--- a/wrappers/wrapper.cpp
+++ b/wrappers/wrapper.cpp
@@ -128,9 +128,9 @@ extern "C" {
 
 #include <stdio.h>
 
-extern "C" void MYCDECL CUSTOM_FREE(void *);
-extern "C" void * MYCDECL CUSTOM_MALLOC(size_t);
-extern "C" void * MYCDECL CUSTOM_CALLOC(size_t nelem, size_t elsize);
+extern "C" void __attribute__((always_inline)) MYCDECL CUSTOM_FREE(void *);
+extern "C" void * __attribute__((always_inline)) MYCDECL CUSTOM_MALLOC(size_t);
+extern "C" void * __attribute__((always_inline)) MYCDECL CUSTOM_CALLOC(size_t nelem, size_t elsize);
 
 extern "C" void MYCDECL CUSTOM_FREE (void * ptr)
 {

```

