### PR TITLE
Illumos build update.

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -18,12 +18,16 @@ else
       $(UNAME_S)-sunw-$(UNAME_P): Heap-Layers
       all: Heap-Layers $(UNAME_S)-sunw-$(UNAME_P)
       install: $(UNAME_S)-sunw-$(UNAME_P)-install
-	@echo "To use Hoard, execute this command: export DYLD_INSERT_LIBRARIES=$(DESTDIR)$(PREFIX)/libhoard.dylib"
+	@echo "To use Hoard, execute this command: export LD_PRELOAD=$(DESTDIR)$(PREFIX)/libhoard.so"
     else
       $(UNAME_S)-gcc-$(UNAME_P): Heap-Layers
       all: Heap-Layers $(UNAME_S)-gcc-$(UNAME_P)
       install: $(UNAME_S)-gcc-$(UNAME_P)-install
-	@echo "To use Hoard, execute this command: export DYLD_INSERT_LIBRARIES=$(DESTDIR)$(PREFIX)/libhoard.dylib"
+        ifeq ($(UNAME_S),Darwin)
+	  @echo "To use Hoard, execute this command: export DYLD_INSERT_LIBRARIES=$(DESTDIR)$(PREFIX)/libhoard.dylib"
+        else
+	  @echo "To use Hoard, execute this command: export LD_PRELOAD=$(DESTDIR)$(PREFIX)/libhoard.so"
+        endif
 endif
 endif
 
@@ -140,9 +144,9 @@ SUNOS_GCC_SPARC_COMPILE_32 = g++ -g -fno-builtin-malloc -nostartfiles -pipe -DND
 
 SUNOS_GCC_SPARC_COMPILE_64 = g++ -g -fno-builtin-malloc -nostartfiles -pipe -DNDEBUG -mcpu=ultrasparc -m64 $(CPPFLAGS) -fPIC -fkeep-inline-functions -finline-functions -ffast-math $(INCLUDES) -D_REENTRANT=1 -shared $(SUNW_SRC) -lthread -lpthread -ldl -o libhoard_64.so
 
-SUNOS_GCC_I386_COMPILE_32 = g++ -g -fno-builtin-malloc -nostartfiles -pipe -DNDEBUG -m32 $(CPPFLAGS) -finline-limit=20000 -fPIC -fkeep-inline-functions -finline-functions -ffast-math $(INCLUDES) -D_REENTRANT=1 -shared $(SUNW_SRC) -lthread -ldl -o libhoard_32.so
+SUNOS_GCC_I386_COMPILE_32 = $(CXX) -g -fno-builtin-malloc -nostartfiles -pipe -DNDEBUG -m32 $(CPPFLAGS) -finline-limit=20000 -fPIC -fkeep-inline-functions -finline-functions -ffast-math $(INCLUDES) -D_REENTRANT=1 -shared $(SUNW_SRC) -lthread -ldl -fno-use-cxa-atexit -o libhoard_32.so
 
-SUNOS_GCC_I386_COMPILE_64 = g++ -g -fno-builtin-malloc -nostartfiles -pipe -DNDEBUG -m64 $(CPPFLAGS) -finline-limit=20000 -fPIC -fkeep-inline-functions -finline-functions -ffast-math $(INCLUDES) -D_REENTRANT=1 -shared $(SUNW_SRC) -lthread -ldl -o libhoard_64.so
+SUNOS_GCC_I386_COMPILE_64 = $(CXX) -g -fno-builtin-malloc -nostartfiles -pipe -DNDEBUG -m64 $(CPPFLAGS) -finline-limit=20000 -fPIC -fkeep-inline-functions -finline-functions -ffast-math $(INCLUDES) -D_REENTRANT=1 -shared $(SUNW_SRC) -lthread -ldl -fno-use-cxa-atexit -o libhoard_64.so
 
 SUNOS_GCC_SPARC_COMPILE_DEBUG = g++ -g -fno-builtin-malloc -nostartfiles -pipe -mcpu=ultrasparc -g -fPIC $(INCLUDES) -D_REENTRANT=1 -shared $(SUNW_SRC) -lthread -lpthread -ldl -o libhoard.so
 
@@ -233,7 +237,7 @@ SunOS-gcc-i386:
 	$(SUNOS_GCC_I386_COMPILE_32)
 	$(SUNOS_GCC_I386_COMPILE_64)
 
-SunOS-gcc-i386-install: SunOS-gcc-sparc
+SunOS-gcc-i386-install: SunOS-gcc-i386
 	cp libhoard_32.so $(DESTDIR)$(PREFIX)
 	cp libhoard_64.so $(DESTDIR)$(PREFIX)
 

--- a/src/include/superblocks/alignedsuperblockheap.h
+++ b/src/include/superblocks/alignedsuperblockheap.h
@@ -37,8 +37,11 @@ namespace Hoard {
       // more chunks (and align them to 64K!) for smaller superblock sizes.
       // Right now, we do not handle this case and just assert here that
       // we are getting chunks of 64K.
-      static_assert(SuperblockSize == 65536,
-		    "This is needed to prevent mmap fragmentation.");
+      //
+      // However on illumos, it does not seem to be the case
+      // but there is no way to distinguish from solaris
+      //static_assert(SuperblockSize == 65536,
+      //		    "This is needed to prevent mmap fragmentation.");
 #endif
     }
     

--- a/src/source/libhoard.cpp
+++ b/src/source/libhoard.cpp
@@ -114,7 +114,7 @@ extern bool isCustomHeapInitialized();
 extern "C" {
 
 #if defined(__GNUG__)
-  void * __attribute__((always_inline)) xxmalloc (size_t sz)
+  inline void * __attribute__((always_inline)) xxmalloc (size_t sz)
 #else
     void * __attribute__((flatten)) xxmalloc (size_t sz) __attribute__((alloc_size(1))) __attribute((malloc))
 #endif
@@ -147,7 +147,7 @@ extern "C" {
   }
 
 #if defined(__GNUG__)
-  void __attribute__((flatten)) __attribute__((always_inline)) xxfree (void * ptr)
+  inline void __attribute__((flatten)) __attribute__((always_inline)) xxfree (void * ptr)
 #else
   void xxfree (void * ptr)
 #endif
@@ -157,7 +157,7 @@ extern "C" {
 
  
 #if defined(__GNUG__)
-  void * __attribute__((always_inline)) xxmemalign (size_t alignment, size_t sz) {
+  inline void * __attribute__((always_inline)) xxmemalign (size_t alignment, size_t sz) {
 #else
   void * xxmemalign (size_t alignment, size_t sz) {
 #endif

--- a/src/source/unixtls.cpp
+++ b/src/source/unixtls.cpp
@@ -54,6 +54,7 @@
 
 #include <new>
 #include <utility>
+#include <iostream>
 
 
 #include "hoard/hoardtlab.h"


### PR DESCRIPTION
Allowing to supersede the compiler as the default gcc 7 is way too old for C++14.