### PR TITLE
Linux musl build fix.

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -34,6 +34,12 @@ ifeq ($(UNAME_S),Darwin)
 PREFIX ?= /usr/local/lib
 else
 PREFIX ?= /usr/lib
+  ifeq ($(UNAME_S),Linux)
+    LINKER_N := $(shell ldd --version 2>&1 | head -n 1 | cut -f 1 -d " ")
+    ifeq ($(LINKER_N),musl)
+        CPPFLAGS = $(CPPFLAGS_NOLTO) -D__MUSL__
+    endif
+  endif
 endif
 
 help:

--- a/src/source/libhoard.cpp
+++ b/src/source/libhoard.cpp
@@ -178,7 +178,7 @@ extern "C" {
 
 } // namespace Hoard
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(__MUSL__)
 // include gnuwrapper here to aid inlining of xxmalloc + friends
 #include "Heap-Layers/wrappers/gnuwrapper.cpp"
 #endif

--- a/src/source/unixtls.cpp
+++ b/src/source/unixtls.cpp
@@ -352,7 +352,7 @@ extern "C" int pthread_create (pthread_t *thread,
                                const pthread_attr_t *attr,
                                void * (*start_routine)(void *),
                                void * arg)
-#if !defined(__SUNPRO_CC) && !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__)
+#if !defined(__SUNPRO_CC) && !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__MUSL__)
   throw ()
 #endif
 {


### PR DESCRIPTION
this libc does not provide a constant (purposely) so no other way
to request the linker to distinguish from glibc.