### PR TITLE
added free_sized symbol

### DIFF
--- a/src/source/libhoard.cpp
+++ b/src/source/libhoard.cpp
@@ -157,7 +157,11 @@ extern "C" {
 #endif
     return generic_xxmemalign(alignment, sz);
   }
-    
+
+  extern "C" void xxfree_sized(void* ptr, size_t) {
+    xxfree(ptr);
+  }
+
   size_t xxmalloc_usable_size (void * ptr) {
     // Handle init buffer pointers
     if (ptr >= initBuffer && ptr < initBuffer + MAX_LOCAL_BUFFER_SIZE) {


### PR DESCRIPTION
*Issue #, if available:*
Fixes #85 

*Description of  #changes:*
Added free_sized symbol to libhoard.cpp. It does not actually perform a sized free, instead uses the traditional free path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
