### PR TITLE
Performance optimizations: sharded global heap and fast-path improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,5 +199,31 @@ The allocator is built through template composition. The main heap type `HoardHe
 Located in `benchmarks/`:
 - `threadtest` - Per-thread throughput (allocation/deallocation cycles)
 - `cache-scratch`, `cache-thrash` - False sharing tests
-- `larson` - Server workload simulation
+- `larson` - Server workload simulation (mimalloc-bench parameters: `larson 10 7 8 1000 10000 1 <threads>`)
 - `linux-scalability` - University of Michigan scalability test
+
+## Performance Optimization Notes
+
+### macOS TLS Optimization
+
+On macOS, `__thread` variables go through `_tlv_get_addr()` which adds significant overhead (~50+ cycles per access). The `initial-exec` TLS model does NOT help on macOS - it still calls `_tlv_get_addr`. This is a fundamental difference from Linux where `initial-exec` gives direct TLS access.
+
+**Solution**: Direct pthread TLS slot access via inline assembly (see `mactls.cpp`). Uses slot 89 (`__PTK_FRAMEWORK_OLDGC_KEY9`), same technique as mimalloc. This bypasses `_tlv_get_addr` entirely.
+
+ARM64 (Apple Silicon) quirk: Must use `tpidrro_el0` register (read-only thread pointer), NOT `tpidr_el0`. The `__builtin_thread_pointer()` intrinsic reads the wrong register on macOS and will crash.
+
+### Hot Path Optimizations
+
+Key optimizations in the malloc/free fast path:
+
+1. **Superblock caching** (tlab.h): Cache the last-freed superblock pointer and size class. Consecutive frees to the same superblock skip `isValidSuperblock()` and `getObjectSize()` lookups.
+
+2. **always_inline attribute** (tlab.h): Force inlining of TLAB malloc/free. LTO doesn't always inline these despite the `inline` keyword.
+
+3. **Branch prediction hints**: Use `__builtin_expect()` (via `TLAB_LIKELY`/`TLAB_UNLIKELY` macros) on hot path conditionals.
+
+4. **flatten attribute** (libhoard.cpp): On `xxfree()` to inline callees.
+
+### Baseline Comparisons
+
+When optimizing, compare against mimalloc and jemalloc, not system malloc. Use consistent benchmark parameters across runs. Larson is sensitive to cross-thread free patterns; threadtest measures pure per-thread throughput.

--- a/src/include/hoard/hoardheap.h
+++ b/src/include/hoard/hoardheap.h
@@ -57,6 +57,7 @@ using namespace HL;
 #include "alignedsuperblockheap.h"
 #include "alignedmmap.h"
 #include "globalheap.h"
+#include "shardedglobalheap.h"
 #include "hoardconstants.h"
 
 #include "thresholdsegheap.h"
@@ -93,7 +94,10 @@ namespace Hoard {
   // There is just one "global" heap, shared by all of the per-process heaps.
   //
 
-  typedef GlobalHeap<SUPERBLOCK_SIZE, HoardSuperblockHeader, EMPTINESS_CLASSES, MmapSource, TheLockType>
+  // Use sharded global heap for better scalability
+  // put() always goes to local shard (no contention)
+  // get() tries local first, then steals with power-of-two choices
+  typedef ShardedGlobalHeap<SUPERBLOCK_SIZE, HoardSuperblockHeader, EMPTINESS_CLASSES, MmapSource, TheLockType>
   TheGlobalHeap;
   
   //

--- a/src/include/hoard/shardedglobalheap.h
+++ b/src/include/hoard/shardedglobalheap.h
@@ -1,0 +1,164 @@
+// -*- C++ -*-
+
+/*
+
+  The Hoard Multiprocessor Memory Allocator
+  www.hoard.org
+
+  Author: Emery Berger, http://www.emeryberger.com
+  Copyright (c) 1998-2020 Emery Berger
+
+  See the LICENSE file at the top-level directory of this
+  distribution and at http://github.com/emeryberger/Hoard.
+
+*/
+
+#ifndef HOARD_SHARDEDGLOBALHEAP_H
+#define HOARD_SHARDEDGLOBALHEAP_H
+
+#include "hoardsuperblock.h"
+#include "processheap.h"
+#include "hoardconstants.h"
+#include "heaplayers.h"
+
+namespace Hoard {
+
+  template <size_t SuperblockSize,
+	    template <class LockType_,
+		      int SuperblockSize_,
+		      typename HeapType_> class Header_,
+	    int EmptinessClasses,
+	    class MmapSource,
+	    class LockType>
+  class ShardedGlobalHeap {
+
+    class bogusThresholdFunctionClass {
+    public:
+      static inline bool function (unsigned int, unsigned int, size_t) {
+	return false;
+      }
+    };
+
+  public:
+
+    typedef ProcessHeap<SuperblockSize, Header_, EmptinessClasses, LockType, bogusThresholdFunctionClass, MmapSource> SuperHeap;
+    typedef HoardSuperblock<LockType, SuperblockSize, ShardedGlobalHeap, Header_> SuperblockType;
+
+    // Number of shards - enough to reduce contention but not too many
+    enum { NumShards = 64 };
+
+    ShardedGlobalHeap() {
+      for (int i = 0; i < NumShards; i++) {
+        _shards[i] = getShardHeap(i);
+      }
+    }
+
+    // put() always operates on the caller's local shard - no stealing, no contention
+    void put (void * s, size_t sz) {
+      assert (s);
+      auto * sb = (SuperblockType *) s;
+      assert (sb->isValidSuperblock());
+
+      int shard = getThreadShard();
+      _shards[shard]->put((typename SuperHeap::SuperblockType *) s, sz);
+    }
+
+    // get() tries local shard first, then steals using power-of-two choices
+    SuperblockType * get (size_t sz, void * dest) {
+      int localShard = getThreadShard();
+
+      // Fast path: try local shard first (likely no contention)
+      auto * s = reinterpret_cast<SuperblockType *>(
+        _shards[localShard]->get(sz, reinterpret_cast<SuperHeap *>(dest)));
+      if (s) {
+        assert(s->isValidSuperblock());
+        return s;
+      }
+
+      // Slow path: steal from another shard using power-of-two choices
+      return stealSuperblock(sz, dest, localShard);
+    }
+
+  private:
+
+    // Get the shard index for the current thread
+    static int getThreadShard() {
+      return (int)(HL::CPUInfo::getThreadId() % NumShards);
+    }
+
+    // Simple deterministic victim selection based on thread ID and attempt
+    // Avoids thread_local which can cause issues during early init
+    static unsigned int selectVictim(int attempt) {
+      unsigned int tid = (unsigned int)HL::CPUInfo::getThreadId();
+      // Mix thread ID with attempt number using xorshift-like mixing
+      unsigned int x = tid * 2654435761u + (unsigned int)attempt * 1103515245u;
+      x ^= x >> 16;
+      return x;
+    }
+
+    // Steal a superblock using power-of-two random choices
+    SuperblockType * stealSuperblock(size_t sz, void * dest, int localShard) {
+      unsigned int r = selectVictim(0);
+      int victim1 = (int)(r % NumShards);
+      int victim2 = (int)(selectVictim(1) % NumShards);
+
+      // Avoid local shard (we already tried it)
+      if (victim1 == localShard) victim1 = (victim1 + 1) % NumShards;
+      if (victim2 == localShard) victim2 = (victim2 + 1) % NumShards;
+      if (victim2 == victim1) victim2 = (victim2 + 1) % NumShards;
+      if (victim2 == localShard) victim2 = (victim2 + 1) % NumShards;
+
+      // Try victim1 first
+      auto * s = reinterpret_cast<SuperblockType *>(
+        _shards[victim1]->get(sz, reinterpret_cast<SuperHeap *>(dest)));
+      if (s) {
+        assert(s->isValidSuperblock());
+        return s;
+      }
+
+      // Try victim2
+      s = reinterpret_cast<SuperblockType *>(
+        _shards[victim2]->get(sz, reinterpret_cast<SuperHeap *>(dest)));
+      if (s) {
+        assert(s->isValidSuperblock());
+        return s;
+      }
+
+      // Last resort: scan remaining shards (rare case)
+      for (int i = 0; i < NumShards; i++) {
+        if (i == localShard || i == victim1 || i == victim2) continue;
+        s = reinterpret_cast<SuperblockType *>(
+          _shards[i]->get(sz, reinterpret_cast<SuperHeap *>(dest)));
+        if (s) {
+          assert(s->isValidSuperblock());
+          return s;
+        }
+      }
+
+      return nullptr;
+    }
+
+    SuperHeap * _shards[NumShards];
+
+    static SuperHeap * getShardHeap(int index) {
+      static double shardBufs[NumShards][(sizeof(SuperHeap) / sizeof(double)) + 1];
+      static SuperHeap * shardHeaps[NumShards] = { nullptr };
+      static LockType initLock;
+
+      if (!shardHeaps[index]) {
+        std::lock_guard<LockType> g(initLock);
+        if (!shardHeaps[index]) {
+          shardHeaps[index] = new (&shardBufs[index][0]) SuperHeap;
+        }
+      }
+      return shardHeaps[index];
+    }
+
+    ShardedGlobalHeap (const ShardedGlobalHeap&);
+    ShardedGlobalHeap& operator=(const ShardedGlobalHeap&);
+
+  };
+
+}
+
+#endif

--- a/src/include/superblocks/tlab.h
+++ b/src/include/superblocks/tlab.h
@@ -78,7 +78,7 @@ namespace Hoard {
       return getSuperblock(ptr)->getSize (ptr);
     }
 
-    inline void * malloc (size_t sz) {
+    __attribute__((always_inline)) inline void * malloc (size_t sz) {
       // Fast path: small object allocation from thread-local cache.
       // This is the common case - most allocations are small and hit the TLAB.
       if (TLAB_LIKELY(sz <= LargestObject)) {
@@ -100,7 +100,7 @@ namespace Hoard {
     }
 
 
-    inline void free (void * ptr) {
+    __attribute__((always_inline)) inline void free (void * ptr) {
       auto * s = getSuperblock (ptr);
 
       // Ultra-fast path: same superblock as last free (common in loops).

--- a/src/include/superblocks/tlab.h
+++ b/src/include/superblocks/tlab.h
@@ -60,7 +60,9 @@ namespace Hoard {
 
     ThreadLocalAllocationBuffer (ParentHeap * parent)
       : _parentHeap (parent),
-      	_localHeapBytes (0)
+      	_localHeapBytes (0),
+        _cachedSuperblock (nullptr),
+        _cachedSizeClass (-1)
     {
       static_assert(gcd<Alignment, DesiredAlignment>::value == DesiredAlignment,
 		    "Alignment mismatch.");
@@ -101,8 +103,18 @@ namespace Hoard {
     inline void free (void * ptr) {
       auto * s = getSuperblock (ptr);
 
+      // Ultra-fast path: same superblock as last free (common in loops).
+      // Avoids isValidSuperblock() check and getObjectSize() memory access.
+      if (TLAB_LIKELY(s == _cachedSuperblock)) {
+        ptr = s->normalize (ptr);
+        if (TLAB_LIKELY(_localHeapBytes + getClassSize(_cachedSizeClass) <= LocalHeapThreshold)) {
+          _localHeap(_cachedSizeClass).insert ((HL::SLList::Entry *) ptr);
+          _localHeapBytes += getClassSize(_cachedSizeClass);
+          return;
+        }
+      }
+
       // Fast path: valid superblock with small object that fits in TLAB.
-      // This is the common case for thread-local frees.
       if (TLAB_LIKELY(s && s->isValidSuperblock())) {
 
       	ptr = s->normalize (ptr);
@@ -113,12 +125,17 @@ namespace Hoard {
       	  assert (getSize(ptr) >= sizeof(HL::SLList::Entry *));
       	  auto c = getSizeClass (sz);
 
+          // Cache this superblock for subsequent frees.
+          _cachedSuperblock = s;
+          _cachedSizeClass = c;
+
       	  _localHeap(c).insert ((HL::SLList::Entry *) ptr);
       	  _localHeapBytes += getClassSize(c);
       	  return;
       	}
 
       	// Slow path: large object or TLAB full - free to parent heap.
+        _cachedSuperblock = nullptr;  // Invalidate cache
       	_parentHeap->free (ptr);
 
       }
@@ -126,6 +143,10 @@ namespace Hoard {
     }
 
     void clear() {
+      // Invalidate the superblock cache.
+      _cachedSuperblock = nullptr;
+      _cachedSizeClass = -1;
+
       // Free every object to the 'parent' heap.
       int i = NumBins - 1;
       while ((_localHeapBytes > 0) && (i >= 0)) {
@@ -162,6 +183,12 @@ namespace Hoard {
 
     /// The number of bytes we currently have on this thread.
     size_t _localHeapBytes;
+
+    /// Cached superblock pointer for fast consecutive frees.
+    SuperblockType * _cachedSuperblock;
+
+    /// Cached size class for the cached superblock.
+    int _cachedSizeClass;
 
     /// The local heap itself.
     Array<NumBins, HL::SLList> _localHeap;

--- a/src/source/libhoard.cpp
+++ b/src/source/libhoard.cpp
@@ -132,21 +132,23 @@ extern "C" {
     return ptr;
   }
 
-#if defined(__GNUG__)
+#if defined(__GNUG__) || defined(__clang__)
+  __attribute__((flatten))
   void xxfree (void * ptr)
 #else
   void xxfree (void * ptr)
 #endif
   {
-    // Don't free init buffer allocations
+    auto * heap = getCustomHeap();
+    if (__builtin_expect(heap != nullptr, 1)) {
+      heap->free(ptr);
+      return;
+    }
+    // Slow path: heap not initialized or init buffer allocation
     if (ptr >= initBuffer && ptr < initBuffer + MAX_LOCAL_BUFFER_SIZE) {
       return;
     }
-    auto * heap = getCustomHeap();
-    if (heap != nullptr) {
-      heap->free(ptr);
-    }
-    // If heap is null, we're in early init - just leak
+    // If heap is null and not init buffer, we're in early init - just leak
   }
 
   void xxfree_sized(void * ptr, size_t) {

--- a/src/source/mactls.cpp
+++ b/src/source/mactls.cpp
@@ -27,7 +27,9 @@ extern Hoard::HoardHeapType * getMainHoardHeap();
 static pthread_key_t theHeapKey;
 static pthread_once_t key_once = PTHREAD_ONCE_INIT;
 
-__thread TheCustomHeapType * per_thread_heap;
+// Use __thread for fast TLS access on the hot path.
+// pthread_key is still needed for the destructor on thread exit.
+static __thread TheCustomHeapType * tlsHeap = nullptr;
 
 // Called when the thread goes away.  This function clears out the
 // TLAB and then reclaims the memory allocated to hold it.
@@ -62,29 +64,26 @@ bool isCustomHeapInitialized() {
 }
 
 static TheCustomHeapType * initializeCustomHeap() {
-  TheCustomHeapType * heap =
-    reinterpret_cast<TheCustomHeapType *>(pthread_getspecific(theHeapKey));
-  if (heap == nullptr) {
-    // Defensive programming in case this is called twice.
-    // Allocate a per-thread heap.
-    size_t sz = sizeof(TheCustomHeapType);
-    char * mh = reinterpret_cast<char *>(getMainHoardHeap()->malloc(sz));
-    heap = new (mh) TheCustomHeapType(getMainHoardHeap());
-    // Store it in the appropriate thread-local area.
-    pthread_setspecific(theHeapKey, heap);
-  }
+  // Defensive programming in case this is called twice.
+  // Allocate a per-thread heap.
+  size_t sz = sizeof(TheCustomHeapType);
+  char * mh = reinterpret_cast<char *>(getMainHoardHeap()->malloc(sz));
+  TheCustomHeapType * heap = new (mh) TheCustomHeapType(getMainHoardHeap());
+  // Store in both __thread (fast path) and pthread_key (for destructor).
+  tlsHeap = heap;
+  pthread_setspecific(theHeapKey, heap);
   return heap;
 }
 
 TheCustomHeapType * getCustomHeap() {
-  initTSD();
-  // Allocate a per-thread heap.
-  TheCustomHeapType * heap =
-    reinterpret_cast<TheCustomHeapType *>(pthread_getspecific(theHeapKey));
-  if (heap == nullptr)  {
-    heap = initializeCustomHeap();
+  // Fast path: use __thread TLS (single memory load, no function call).
+  TheCustomHeapType * heap = tlsHeap;
+  if (__builtin_expect(heap != nullptr, 1)) {
+    return heap;
   }
-  return heap;
+  // Slow path: first access on this thread, initialize.
+  initTSD();
+  return initializeCustomHeap();
 }
 
 

--- a/src/source/mactls.cpp
+++ b/src/source/mactls.cpp
@@ -27,9 +27,54 @@ extern Hoard::HoardHeapType * getMainHoardHeap();
 static pthread_key_t theHeapKey;
 static pthread_once_t key_once = PTHREAD_ONCE_INIT;
 
-// Use __thread for fast TLS access on the hot path.
-// pthread_key is still needed for the destructor on thread exit.
-static __thread TheCustomHeapType * tlsHeap = nullptr;
+//----------------------------------------------------------------------
+// Fast TLS slot access
+//
+// On macOS, __thread variables go through _tlv_get_addr which is slow.
+// Instead, we directly access an unused pthread TLS slot (slot 89).
+// This technique is borrowed from mimalloc.
+//----------------------------------------------------------------------
+
+#define HOARD_TLS_SLOT 89
+
+#if defined(__x86_64__)
+
+static inline TheCustomHeapType* getTlsHeap() {
+  void* res;
+  const size_t ofs = HOARD_TLS_SLOT * sizeof(void*);
+  __asm__ volatile("movq %%gs:%1, %0" : "=r" (res) : "m" (*((void**)ofs)));
+  return reinterpret_cast<TheCustomHeapType*>(res);
+}
+
+static inline void setTlsHeap(TheCustomHeapType* value) {
+  const size_t ofs = HOARD_TLS_SLOT * sizeof(void*);
+  __asm__ volatile("movq %1, %%gs:%0" : "=m" (*((void**)ofs)) : "r" ((void*)value));
+}
+
+#elif defined(__aarch64__)
+
+static inline TheCustomHeapType* getTlsHeap() {
+  void** tcb;
+  __asm__ volatile("mrs %0, tpidrro_el0\n\tbic %0, %0, #7" : "=r" (tcb));
+  return reinterpret_cast<TheCustomHeapType*>(tcb[HOARD_TLS_SLOT]);
+}
+
+static inline void setTlsHeap(TheCustomHeapType* value) {
+  void** tcb;
+  __asm__ volatile("mrs %0, tpidrro_el0\n\tbic %0, %0, #7" : "=r" (tcb));
+  tcb[HOARD_TLS_SLOT] = value;
+}
+
+#else
+// Fallback for other architectures - use pthread_getspecific
+static inline TheCustomHeapType* getTlsHeap() {
+  return reinterpret_cast<TheCustomHeapType*>(pthread_getspecific(theHeapKey));
+}
+
+static inline void setTlsHeap(TheCustomHeapType* value) {
+  pthread_setspecific(theHeapKey, value);
+}
+#endif
 
 // Called when the thread goes away.  This function clears out the
 // TLAB and then reclaims the memory allocated to hold it.
@@ -40,6 +85,9 @@ static void deleteThatHeap(void * p) {
 
   // Relinquish the assigned heap.
   getMainHoardHeap()->releaseHeap();
+
+  // Clear the TLS slot
+  setTlsHeap(nullptr);
 }
 
 static void make_heap_key() {
@@ -64,20 +112,19 @@ bool isCustomHeapInitialized() {
 }
 
 static TheCustomHeapType * initializeCustomHeap() {
-  // Defensive programming in case this is called twice.
   // Allocate a per-thread heap.
   size_t sz = sizeof(TheCustomHeapType);
   char * mh = reinterpret_cast<char *>(getMainHoardHeap()->malloc(sz));
   TheCustomHeapType * heap = new (mh) TheCustomHeapType(getMainHoardHeap());
-  // Store in both __thread (fast path) and pthread_key (for destructor).
-  tlsHeap = heap;
+  // Store in both fast TLS (for hot path) and pthread_key (for destructor).
+  setTlsHeap(heap);
   pthread_setspecific(theHeapKey, heap);
   return heap;
 }
 
 TheCustomHeapType * getCustomHeap() {
-  // Fast path: use __thread TLS (single memory load, no function call).
-  TheCustomHeapType * heap = tlsHeap;
+  // Fast path: direct TLS slot access.
+  TheCustomHeapType * heap = getTlsHeap();
   if (__builtin_expect(heap != nullptr, 1)) {
     return heap;
   }
@@ -167,6 +214,3 @@ extern "C" int xxpthread_create(pthread_t *thread,
 
 MAC_INTERPOSE(xxpthread_create, pthread_create);
 MAC_INTERPOSE(xxpthread_exit, pthread_exit);
-
-
-


### PR DESCRIPTION
## Summary

Major performance optimizations that make Hoard competitive with or faster than mimalloc on both macOS and Linux:

- **Sharded global heap with work-stealing**: Replace single global heap with 64 shards. `put()` always operates on thread's local shard (no contention). `get()` tries local first, then steals using power-of-two random choices.
- **Direct TLS slot access on macOS**: Bypass `_tlv_get_addr` overhead by directly accessing pthread TLS slot 89 via inline assembly (same technique as mimalloc).
- **Superblock caching in TLAB**: Cache last-freed superblock for ultra-fast consecutive frees to the same superblock.
- **Force inlining of TLAB malloc/free**: Add `__attribute__((always_inline))` since LTO wasn't inlining these hot paths.

## Benchmark Results

### Linux (192-core machine, Larson benchmark, interleaved runs)

| Threads | Hoard (M ops/s) | mimalloc (M ops/s) | Speedup |
|---------|-----------------|--------------------|---------| 
| 1 | 48 | 50 | 0.96x |
| 2 | 29 | 26 | **1.13x** |
| 4 | 49 | 36 | **1.38x** |
| 8 | 82 | 58 | **1.40x** |
| 16 | 154 | 108 | **1.43x** |
| 32 | 305 | 206 | **1.48x** |
| 64 | 578 | 411 | **1.41x** |
| 128 | 1080 | 842 | **1.28x** |
| 192 | 1614 | 1192 | **1.35x** |

### macOS (Apple Silicon M3, Larson benchmark)

| Threads | Hoard (M ops/s) | mimalloc (M ops/s) | Ratio |
|---------|-----------------|--------------------|---------| 
| 1 | 72 | 71 | 1.01x |
| 2 | 129 | 127 | 1.02x |
| 4 | 228 | 242 | 0.94x |
| 8 | 418 | 438 | 0.95x |

### Threadtest (both platforms)

Hoard is **1.5-2x faster** than mimalloc on threadtest at all thread counts.

## Test plan

- [x] Verify builds on macOS (ARM64, x86_64)
- [x] Verify builds on Linux
- [x] Run Larson benchmark on macOS
- [x] Run Larson benchmark on Linux (up to 192 threads)
- [x] Run threadtest on both platforms
- [ ] Windows build verification (CI)