### PR TITLE
Experiment: 256KB superblocks on Windows (raises BIG_OBJECT 8KB → 32KB)

### DIFF
--- a/.github/scripts/benchmark-watchdog.ps1
+++ b/.github/scripts/benchmark-watchdog.ps1
@@ -21,20 +21,27 @@ $exe = $Cmd[0]
 $cmdArgs = if ($Cmd.Count -gt 1) { $Cmd[1..($Cmd.Count-1)] } else { @() }
 
 Write-Host "--- $Name ---"
-# Run through cmd.exe with shell redirection: unlike Start-Process handle
-# redirection, cmd's redirected handles are inherited by the whole process
-# tree, so the benchmark's own output (grandchild under withdll) is captured
-# too, not just withdll's banner.
-$quoted = @($exe) + $cmdArgs | ForEach-Object { '"' + $_ + '"' }
-$cmdLine = ($quoted -join ' ') + ' > "' + $outFile + '" 2> "' + $errFile + '"'
-$p = Start-Process -FilePath $env:ComSpec -ArgumentList @('/d', '/c', $cmdLine) `
+# Run through a generated .cmd script: shell redirection makes the handles
+# inheritable by the whole process tree (so the benchmark grandchild under
+# withdll is captured, not just withdll's banner), and a script file
+# sidesteps cmd.exe's multi-quote command-line parsing entirely.
+$quoted = (@($exe) + $cmdArgs | ForEach-Object { '"' + $_ + '"' }) -join ' '
+$scriptFile = Join-Path $OutDir "$Name.cmd"
+@(
+  '@echo off',
+  "$quoted > `"$outFile`" 2> `"$errFile`"",
+  'exit /b %ERRORLEVEL%'
+) | Set-Content -Path $scriptFile -Encoding ASCII
+$p = Start-Process -FilePath $env:ComSpec -ArgumentList @('/d', '/c', $scriptFile) `
      -NoNewWindow -PassThru
+# Touch the handle immediately: PowerShell acquires process handles lazily,
+# and without this .ExitCode is permanently null (reads as exit 0).
+$null = $p.Handle
 
 $finished = $p.WaitForExit($TimeoutSec * 1000)
 if ($finished) {
   # Drain the process object: after a timed WaitForExit, .ExitCode is not
-  # populated until a final untimed WaitForExit() call. Without this the
-  # script exits with $null (= 0), masking benchmark crashes entirely.
+  # populated until a final untimed WaitForExit() call.
   $p.WaitForExit()
 }
 

--- a/.github/scripts/benchmark-watchdog.ps1
+++ b/.github/scripts/benchmark-watchdog.ps1
@@ -59,6 +59,22 @@ if ($finished) {
   $code = $p.ExitCode
   if ($null -eq $code) { $code = -1 }
   Write-Host "$Name exited with $code"
+  if ($code -lt -1) {
+    # NTSTATUS-style exit (e.g. -1073741819 = 0xC0000005 access violation):
+    # re-run once under cdb to capture the faulting stack and a minidump.
+    $cdb = @(
+      "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe",
+      "C:\Program Files\Windows Kits\10\Debuggers\x64\cdb.exe"
+    ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if ($cdb) {
+      Write-Host "### $Name crashed - re-running under cdb for the faulting stack ###"
+      $env:_NT_SYMBOL_PATH = "srv*C:\symbols*https://msdl.microsoft.com/download/symbols"
+      $crashLog = Join-Path $OutDir "$Name-crash-stacks.txt"
+      $crashDump = Join-Path $OutDir "$Name-crash.dmp"
+      & $cdb -G -o -c ".lines; g; !analyze -v; ~*kb 64; .dump /ma `"$crashDump`"; q" `
+        @(@($exe) + $cmdArgs) 2>&1 | Tee-Object -FilePath $crashLog | Select-Object -Last 80 | Write-Host
+    }
+  }
   exit $code
 }
 

--- a/.github/scripts/benchmark-watchdog.ps1
+++ b/.github/scripts/benchmark-watchdog.ps1
@@ -69,10 +69,22 @@ if ($finished) {
     if ($cdb) {
       Write-Host "### $Name crashed - re-running under cdb for the faulting stack ###"
       $env:_NT_SYMBOL_PATH = "srv*C:\symbols*https://msdl.microsoft.com/download/symbols"
-      $crashLog = Join-Path $OutDir "$Name-crash-stacks.txt"
-      $crashDump = Join-Path $OutDir "$Name-crash.dmp"
-      & $cdb -G -o -c ".lines; g; !analyze -v; ~*kb 64; .dump /ma `"$crashDump`"; q" `
-        @(@($exe) + $cmdArgs) 2>&1 | Tee-Object -FilePath $crashLog | Select-Object -Last 80 | Write-Host
+      # sxd ibp/epr: don't stop on initial breakpoints or process exit, so
+      # the first stop after g is the actual exception. -o follows the
+      # benchmark child under withdll. The crash is nondeterministic, so
+      # retry a few times until a run faults under the debugger.
+      for ($try = 1; $try -le 5; $try++) {
+        $crashLog = Join-Path $OutDir "$Name-crash-try$try.txt"
+        $crashDump = Join-Path $OutDir "$Name-crash.dmp"
+        & $cdb -G -o -c ".lines; sxd ibp; sxd epr; g; !analyze -v; ~*kb 64; .dump /ma `"$crashDump`"; q" `
+          @(@($exe) + $cmdArgs) 2>&1 | Set-Content -Path $crashLog
+        if (Select-String -Path $crashLog -Pattern "EXCEPTION_RECORD|Access violation|c0000005" -Quiet) {
+          Write-Host "### crash reproduced under cdb on try $try ###"
+          Get-Content $crashLog | Select-Object -Last 100 | Write-Host
+          break
+        }
+        Write-Host "  (no fault under cdb on try $try)"
+      }
     }
   }
   exit $code

--- a/.github/scripts/benchmark-watchdog.ps1
+++ b/.github/scripts/benchmark-watchdog.ps1
@@ -21,15 +21,22 @@ $exe = $Cmd[0]
 $cmdArgs = if ($Cmd.Count -gt 1) { $Cmd[1..($Cmd.Count-1)] } else { @() }
 
 Write-Host "--- $Name ---"
-if ($cmdArgs.Count -gt 0) {
-  $p = Start-Process -FilePath $exe -ArgumentList $cmdArgs -NoNewWindow -PassThru `
-       -RedirectStandardOutput $outFile -RedirectStandardError $errFile
-} else {
-  $p = Start-Process -FilePath $exe -NoNewWindow -PassThru `
-       -RedirectStandardOutput $outFile -RedirectStandardError $errFile
-}
+# Run through cmd.exe with shell redirection: unlike Start-Process handle
+# redirection, cmd's redirected handles are inherited by the whole process
+# tree, so the benchmark's own output (grandchild under withdll) is captured
+# too, not just withdll's banner.
+$quoted = @($exe) + $cmdArgs | ForEach-Object { '"' + $_ + '"' }
+$cmdLine = ($quoted -join ' ') + ' > "' + $outFile + '" 2> "' + $errFile + '"'
+$p = Start-Process -FilePath $env:ComSpec -ArgumentList @('/d', '/c', $cmdLine) `
+     -NoNewWindow -PassThru
 
 $finished = $p.WaitForExit($TimeoutSec * 1000)
+if ($finished) {
+  # Drain the process object: after a timed WaitForExit, .ExitCode is not
+  # populated until a final untimed WaitForExit() call. Without this the
+  # script exits with $null (= 0), masking benchmark crashes entirely.
+  $p.WaitForExit()
+}
 
 # Mirror benchmark output into the console and the aggregate log.
 $output = @()
@@ -42,8 +49,10 @@ if ($LogFile) {
 }
 
 if ($finished) {
-  Write-Host "$Name exited with $($p.ExitCode)"
-  exit $p.ExitCode
+  $code = $p.ExitCode
+  if ($null -eq $code) { $code = -1 }
+  Write-Host "$Name exited with $code"
+  exit $code
 }
 
 Write-Host "### $Name HUNG after ${TimeoutSec}s - capturing process-tree stacks ###"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -328,14 +328,20 @@ jobs:
           $timeouts = @{ "rptest" = 900 }
 
           $failed = @()
-          foreach ($b in $benchmarks) {
-            $name = $b[0]
-            $tmo = if ($timeouts.ContainsKey($name)) { $timeouts[$name] } else { 120 }
-            $cmd = @($withdll, "/d:$hoard") + $b[1..($b.Count-1)]
-            powershell -NoProfile -ExecutionPolicy Bypass -File $watchdog `
-              -Name $name -TimeoutSec $tmo -OutDir watchdog -LogFile hoard.txt @cmd
-            if ($LASTEXITCODE -ne 0) {
-              $failed += "$name (exit $LASTEXITCODE)"
+          # Experiment branch: the remaining Windows-256KB crash is a rare
+          # race (~12% per benchmark execution); loop the suite to make a
+          # single CI run statistically near-certain to reproduce it under
+          # the crash-capture watchdog.
+          foreach ($iter in 1..5) {
+            foreach ($b in $benchmarks) {
+              $name = "$($b[0])-i$iter"
+              $tmo = if ($timeouts.ContainsKey($b[0])) { $timeouts[$b[0]] } else { 120 }
+              $cmd = @($withdll, "/d:$hoard") + $b[1..($b.Count-1)]
+              powershell -NoProfile -ExecutionPolicy Bypass -File $watchdog `
+                -Name $name -TimeoutSec $tmo -OutDir watchdog -LogFile hoard.txt @cmd
+              if ($LASTEXITCODE -ne 0) {
+                $failed += "$name (exit $LASTEXITCODE)"
+              }
             }
           }
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -328,20 +328,14 @@ jobs:
           $timeouts = @{ "rptest" = 900 }
 
           $failed = @()
-          # Experiment branch: the remaining Windows-256KB crash is a rare
-          # race (~12% per benchmark execution); loop the suite to make a
-          # single CI run statistically near-certain to reproduce it under
-          # the crash-capture watchdog.
-          foreach ($iter in 1..5) {
-            foreach ($b in $benchmarks) {
-              $name = "$($b[0])-i$iter"
-              $tmo = if ($timeouts.ContainsKey($b[0])) { $timeouts[$b[0]] } else { 120 }
-              $cmd = @($withdll, "/d:$hoard") + $b[1..($b.Count-1)]
-              powershell -NoProfile -ExecutionPolicy Bypass -File $watchdog `
-                -Name $name -TimeoutSec $tmo -OutDir watchdog -LogFile hoard.txt @cmd
-              if ($LASTEXITCODE -ne 0) {
-                $failed += "$name (exit $LASTEXITCODE)"
-              }
+          foreach ($b in $benchmarks) {
+            $name = $b[0]
+            $tmo = if ($timeouts.ContainsKey($name)) { $timeouts[$name] } else { 120 }
+            $cmd = @($withdll, "/d:$hoard") + $b[1..($b.Count-1)]
+            powershell -NoProfile -ExecutionPolicy Bypass -File $watchdog `
+              -Name $name -TimeoutSec $tmo -OutDir watchdog -LogFile hoard.txt @cmd
+            if ($LASTEXITCODE -ne 0) {
+              $failed += "$name (exit $LASTEXITCODE)"
             }
           }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ if(WIN32)
   #
   set(HOARD_SOURCES ${WINDOWS_SOURCES})
   add_definitions(-DNDEBUG -D_CRT_SECURE_NO_WARNINGS -DWIN32_LEAN_AND_MEAN -DALLOC8_NO_DLLMAIN)
+  # Compile-time inline ownership hook for alloc8's Windows wrapper:
+  # replaces SEH-probe foreign-pointer detection (which dereferences
+  # masked addresses and, after init, skipped checking entirely) with
+  # Hoard's O(1) ownership map. See hoardownsinline.h.
+  add_definitions(-DALLOC8_XXOWNS_INLINE_HEADER=\"hoardownsinline.h\")
 
 elseif(APPLE)
   set(HOARD_SOURCES ${MACOS_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,7 @@ include_directories(${printf_SOURCE_DIR})
 FetchContent_Declare(
   alloc8
   GIT_REPOSITORY https://github.com/emeryberger/alloc8.git
-  # TEMPORARY (experiment branch only): pin to the Windows ownership-hook
-  # branch (alloc8#11) until it merges; revert to main before merging.
-  GIT_TAG        win-xxowns-hook
+  GIT_TAG        main
   GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(alloc8)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,9 @@ include_directories(${printf_SOURCE_DIR})
 FetchContent_Declare(
   alloc8
   GIT_REPOSITORY https://github.com/emeryberger/alloc8.git
-  GIT_TAG        main
+  # TEMPORARY (experiment branch only): pin to the Windows ownership-hook
+  # branch (alloc8#11) until it merges; revert to main before merging.
+  GIT_TAG        win-xxowns-hook
   GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(alloc8)

--- a/src/include/hoard/hoardheap.h
+++ b/src/include/hoard/hoardheap.h
@@ -26,13 +26,16 @@ using namespace HL;
 // that is, we carve objects out of chunks of this size.
 
 
-#if defined(_WIN32)
-// Larger superblock sizes are not yet working for Windows for some reason to be determined.
-#define SUPERBLOCK_SIZE 65536UL
-#else
+// 256KB superblocks on all platforms. Windows historically used 64KB
+// with a note that larger sizes were "not working"; retrying now that
+// the DllMain initialization deadlock and MSVC implicit-lifetime
+// breakage are fixed. 256KB raises the Windows big-object threshold
+// from 8KB to 32KB (fewer objects funneled through the serialized
+// mmap layer) and enables the fine-grained bins256k size classes and
+// the TLAB size-class LUT on Windows.
 #define SUPERBLOCK_SIZE 262144UL
 // unclear why this is not working with 524288UL and larger...
-#endif
+
 
 //#define SUPERBLOCK_SIZE (256*1048576)
 //#define SUPERBLOCK_SIZE (512*1048576)

--- a/src/include/hoard/hoardownsinline.h
+++ b/src/include/hoard/hoardownsinline.h
@@ -49,10 +49,16 @@ extern "C" {
 }
 
 static inline bool alloc8_xxowns_inline (const void * ptr) {
+#if defined(__GNUC__) || defined(__clang__)
   if (__builtin_expect(
         Hoard::OwnershipMap<HOARD_OWNS_CHUNK_SIZE>::contains (ptr), 1)) {
     return true;
   }
+#else
+  if (Hoard::OwnershipMap<HOARD_OWNS_CHUNK_SIZE>::contains (ptr)) {
+    return true;
+  }
+#endif
   auto * p = reinterpret_cast<const char *>(ptr);
   return (p >= hoardInitBufferStart && p < hoardInitBufferEnd);
 }

--- a/src/include/util/alignedmmap.h
+++ b/src/include/util/alignedmmap.h
@@ -140,6 +140,44 @@ namespace Hoard {
 
     void * slowMap (size_t sz) {
 
+#if defined(_WIN32)
+
+      // VirtualFree(MEM_RELEASE) cannot release a subrange of an
+      // allocation: it frees the entire region containing the base
+      // pointer and ignores the size. The Unix approach below (map
+      // oversized, trim the misaligned ends) therefore silently
+      // releases the very region being returned - this is why
+      // superblocks larger than the 64KB allocation granularity never
+      // worked on Windows. Instead: reserve an oversized block just to
+      // discover an aligned address, release it, then re-reserve
+      // exactly at that address, retrying if another thread claims the
+      // range in the window between the two calls.
+
+#if HL_EXECUTABLE_HEAP
+      const DWORD permflags = PAGE_EXECUTE_READWRITE;
+#else
+      const DWORD permflags = PAGE_READWRITE;
+#endif
+      for (int attempts = 0; attempts < 64; attempts++) {
+        void * probe = VirtualAlloc (nullptr, sz + Alignment, MEM_RESERVE, PAGE_NOACCESS);
+        if (probe == nullptr) {
+          return nullptr;
+        }
+        auto * aligned =
+          reinterpret_cast<void *>(HL::align<Alignment>((size_t) probe));
+        VirtualFree (probe, 0, MEM_RELEASE);
+        void * p = VirtualAlloc (aligned, sz, MEM_RESERVE | MEM_COMMIT, permflags);
+        if (p != nullptr) {
+          assert ((size_t) p % Alignment == 0);
+          OwnershipMap<Alignment>::set (p, sz);
+          return p;
+        }
+        // Lost the race for that address range; try again.
+      }
+      return nullptr;
+
+#else
+
       // We have to align it ourselves. We get memory from
       // mmap, align a pointer in the space, and free the space before
       // and after the aligned segment.
@@ -172,6 +210,8 @@ namespace Hoard {
 #endif
       OwnershipMap<Alignment>::set (newptr, sz);
       return newptr;
+
+#endif // _WIN32
     }
 
     // Manage information in a map that uses a custom heap for

--- a/src/include/util/ownershipmap.h
+++ b/src/include/util/ownershipmap.h
@@ -41,7 +41,12 @@
 #include <cstdint>
 #include <cstddef>
 
-#if !defined(_WIN32)
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
 #include <sys/mman.h>
 #ifndef MAP_NORESERVE
 #define MAP_NORESERVE 0
@@ -55,6 +60,23 @@ namespace Hoard {
   public:
 
     static inline bool contains (const void * p) {
+      auto a = reinterpret_cast<uintptr_t>(p);
+      if (a >= MaxAddress) {
+        return false;
+      }
+#if defined(_WIN32)
+      auto * l1 = _l1.load (std::memory_order_acquire);
+      if (l1 == nullptr) {
+        return false;
+      }
+      auto * l2 = l1[a / L2Span].load (std::memory_order_acquire);
+      if (l2 == nullptr) {
+        return false;
+      }
+      size_t chunk = (a % L2Span) / ChunkSize;
+      uint64_t word = l2[chunk >> 6].load (std::memory_order_relaxed);
+      return (word >> (chunk & 63)) & 1;
+#else
       // Relaxed load on the hot path: the pointer is written exactly
       // once (before any Hoard-owned pointer can be freed), and the
       // subsequent array access carries an address dependency. Fall
@@ -70,18 +92,26 @@ namespace Hoard {
           return false;
         }
       }
-      auto a = reinterpret_cast<uintptr_t>(p);
-      if (a >= MaxAddress) {
-        return false;
-      }
       size_t chunk = a / ChunkSize;
       uint64_t word = bits[chunk >> 6].load (std::memory_order_relaxed);
       return (word >> (chunk & 63)) & 1;
+#endif
     }
 
     // Register [start, start+len) as Hoard-owned. Called with len a
     // multiple of ChunkSize and start ChunkSize-aligned.
     static void set (void * start, size_t len) {
+#if defined(_WIN32)
+      forEachChunkAddr (start, len, [] (uintptr_t a) {
+        auto * l2 = ensureL2 (a);
+        if (l2 == nullptr) {
+          return;
+        }
+        size_t chunk = (a % L2Span) / ChunkSize;
+        l2[chunk >> 6].fetch_or (1ULL << (chunk & 63),
+                                 std::memory_order_release);
+      });
+#else
       auto * bits = ensureBits();
       if (bits == nullptr) {
         return;
@@ -90,9 +120,25 @@ namespace Hoard {
         bits[chunk >> 6].fetch_or (1ULL << (chunk & 63),
                                    std::memory_order_release);
       });
+#endif
     }
 
     static void clear (void * start, size_t len) {
+#if defined(_WIN32)
+      auto * l1 = _l1.load (std::memory_order_acquire);
+      if (l1 == nullptr) {
+        return;
+      }
+      forEachChunkAddr (start, len, [l1] (uintptr_t a) {
+        auto * l2 = l1[a / L2Span].load (std::memory_order_acquire);
+        if (l2 == nullptr) {
+          return;
+        }
+        size_t chunk = (a % L2Span) / ChunkSize;
+        l2[chunk >> 6].fetch_and (~(1ULL << (chunk & 63)),
+                                  std::memory_order_release);
+      });
+#else
       auto * bits = _bits.load (std::memory_order_acquire);
       if (bits == nullptr) {
         return;
@@ -101,6 +147,7 @@ namespace Hoard {
         bits[chunk >> 6].fetch_and (~(1ULL << (chunk & 63)),
                                     std::memory_order_release);
       });
+#endif
     }
 
   private:
@@ -108,6 +155,16 @@ namespace Hoard {
     static constexpr uintptr_t MaxAddress = 1ULL << 48;
     static constexpr size_t NumChunks = MaxAddress / ChunkSize;
     static constexpr size_t NumWords = NumChunks / 64;
+
+#if defined(_WIN32)
+    // Windows has no overcommit: a flat 128MB bitmap would charge the
+    // pagefile up front. Use a two-level radix instead: a small L1
+    // pointer array (committed once) whose entries each cover 64GB of
+    // address space via an on-demand-committed L2 bitmap.
+    static constexpr uintptr_t L2Span = 1ULL << 36; // 64GB per L2 node
+    static constexpr size_t L1Entries = MaxAddress / L2Span; // 4096
+    static constexpr size_t L2Words = (L2Span / ChunkSize) / 64;
+#endif
 
     template <class F>
     static void forEachChunk (void * start, size_t len, F f) {
@@ -122,12 +179,68 @@ namespace Hoard {
       }
     }
 
+#if defined(_WIN32)
+    /// Like forEachChunk but passes the chunk's base address.
+    template <class F>
+    static void forEachChunkAddr (void * start, size_t len, F f) {
+      auto a = reinterpret_cast<uintptr_t>(start);
+      if (a >= MaxAddress) {
+        return;
+      }
+      uintptr_t first = (a / ChunkSize) * ChunkSize;
+      uintptr_t lastEx = ((a + len + ChunkSize - 1) / ChunkSize) * ChunkSize;
+      for (uintptr_t c = first; c < lastEx && c < MaxAddress; c += ChunkSize) {
+        f (c);
+      }
+    }
+
+    static std::atomic<uint64_t> * ensureL2 (uintptr_t a) {
+      auto * l1 = _l1.load (std::memory_order_acquire);
+      if (l1 == nullptr) {
+        void * mem = VirtualAlloc (nullptr,
+                                   L1Entries * sizeof(void *),
+                                   MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        if (mem == nullptr) {
+          return nullptr;
+        }
+        auto * fresh =
+          reinterpret_cast<std::atomic<std::atomic<uint64_t> *> *>(mem);
+        std::atomic<std::atomic<uint64_t> *> * expected = nullptr;
+        if (!_l1.compare_exchange_strong (expected, fresh,
+                                          std::memory_order_acq_rel)) {
+          VirtualFree (mem, 0, MEM_RELEASE);
+          l1 = expected;
+        } else {
+          l1 = fresh;
+        }
+      }
+      auto & slot = l1[a / L2Span];
+      auto * l2 = slot.load (std::memory_order_acquire);
+      if (l2 != nullptr) {
+        return l2;
+      }
+      void * mem = VirtualAlloc (nullptr, L2Words * sizeof(uint64_t),
+                                 MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+      if (mem == nullptr) {
+        return nullptr;
+      }
+      auto * fresh = reinterpret_cast<std::atomic<uint64_t> *>(mem);
+      std::atomic<uint64_t> * expected = nullptr;
+      if (!slot.compare_exchange_strong (expected, fresh,
+                                         std::memory_order_acq_rel)) {
+        VirtualFree (mem, 0, MEM_RELEASE);
+        return expected;
+      }
+      return fresh;
+    }
+#endif
+
+#if !defined(_WIN32)
     static std::atomic<uint64_t> * ensureBits() {
       auto * bits = _bits.load (std::memory_order_acquire);
       if (bits != nullptr) {
         return bits;
       }
-#if !defined(_WIN32)
       void * p = mmap (nullptr, NumWords * sizeof(uint64_t),
                        PROT_READ | PROT_WRITE,
                        MAP_PRIVATE | MAP_ANON | MAP_NORESERVE, -1, 0);
@@ -142,20 +255,27 @@ namespace Hoard {
         return expected;
       }
       return fresh;
-#else
-      return nullptr;
-#endif
     }
+#endif
 
-    // Defined out of line below. NOTE: deliberately not an inline
-    // static member: libhoard.cpp does `#define inline __forceinline`
+    // Defined out of line below. NOTE: deliberately not inline
+    // static members: libhoard.cpp does `#define inline __forceinline`
     // on Windows, which is invalid on data declarations; a template's
     // static member may be defined in a header without `inline`.
+#if defined(_WIN32)
+    static std::atomic<std::atomic<std::atomic<uint64_t> *> *> _l1;
+#else
     static std::atomic<std::atomic<uint64_t> *> _bits;
+#endif
   };
 
+#if defined(_WIN32)
+  template <size_t ChunkSize>
+  std::atomic<std::atomic<std::atomic<uint64_t> *> *> OwnershipMap<ChunkSize>::_l1 { nullptr };
+#else
   template <size_t ChunkSize>
   std::atomic<std::atomic<uint64_t> *> OwnershipMap<ChunkSize>::_bits { nullptr };
+#endif
 
 }
 

--- a/src/source/libhoard.cpp
+++ b/src/source/libhoard.cpp
@@ -145,7 +145,7 @@ extern bool isCustomHeapInitialized();
 
 #include "wrappers/generic-memalign.cpp"
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(_WIN32)
 
 // Ownership hook consumed by the alloc8 interposition layer. Providing
 // these strong definitions makes alloc8 skip its internal per-pointer


### PR DESCRIPTION
**Draft / CI experiment — do not merge yet.**

Tests whether the historical "larger superblock sizes are not yet working for Windows" limitation still holds now that the DllMain initialization deadlock (#100) and the MSVC implicit-lifetime breakage (Heap-Layers#73) are fixed — both are plausible original culprits for that note.

If Windows is happy with 256KB superblocks, this:
- raises the Windows big-object threshold from **8KB to 32KB**, routing the heavily-used 8–32KB range through per-thread superblock heaps instead of one global mmap lock with a VM syscall pair per object (the mechanism behind rptest's ~10-minute crawl — see #100);
- enables the fine-grained `bins256k` size classes (≤25% worst-case internal fragmentation) and the TLAB size-class LUT on Windows, matching macOS/Linux.

Branched from #99 (needs its deadlock fix to run at all). The benchmark watchdog will produce stacks/dumps if anything hangs. Judge by: build-windows green + benchmark timings in the artifacts (especially rptest vs. its historical ~10 minutes).

Context: https://github.com/emeryberger/Hoard/issues/100, discussion in #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)