### PR TITLE
CI watchdog: propagate real exit codes and capture full process-tree output

### DIFF
--- a/.github/scripts/benchmark-watchdog.ps1
+++ b/.github/scripts/benchmark-watchdog.ps1
@@ -21,20 +21,27 @@ $exe = $Cmd[0]
 $cmdArgs = if ($Cmd.Count -gt 1) { $Cmd[1..($Cmd.Count-1)] } else { @() }
 
 Write-Host "--- $Name ---"
-# Run through cmd.exe with shell redirection: unlike Start-Process handle
-# redirection, cmd's redirected handles are inherited by the whole process
-# tree, so the benchmark's own output (grandchild under withdll) is captured
-# too, not just withdll's banner.
-$quoted = @($exe) + $cmdArgs | ForEach-Object { '"' + $_ + '"' }
-$cmdLine = ($quoted -join ' ') + ' > "' + $outFile + '" 2> "' + $errFile + '"'
-$p = Start-Process -FilePath $env:ComSpec -ArgumentList @('/d', '/c', $cmdLine) `
+# Run through a generated .cmd script: shell redirection makes the handles
+# inheritable by the whole process tree (so the benchmark grandchild under
+# withdll is captured, not just withdll's banner), and a script file
+# sidesteps cmd.exe's multi-quote command-line parsing entirely.
+$quoted = (@($exe) + $cmdArgs | ForEach-Object { '"' + $_ + '"' }) -join ' '
+$scriptFile = Join-Path $OutDir "$Name.cmd"
+@(
+  '@echo off',
+  "$quoted > `"$outFile`" 2> `"$errFile`"",
+  'exit /b %ERRORLEVEL%'
+) | Set-Content -Path $scriptFile -Encoding ASCII
+$p = Start-Process -FilePath $env:ComSpec -ArgumentList @('/d', '/c', $scriptFile) `
      -NoNewWindow -PassThru
+# Touch the handle immediately: PowerShell acquires process handles lazily,
+# and without this .ExitCode is permanently null (reads as exit 0).
+$null = $p.Handle
 
 $finished = $p.WaitForExit($TimeoutSec * 1000)
 if ($finished) {
   # Drain the process object: after a timed WaitForExit, .ExitCode is not
-  # populated until a final untimed WaitForExit() call. Without this the
-  # script exits with $null (= 0), masking benchmark crashes entirely.
+  # populated until a final untimed WaitForExit() call.
   $p.WaitForExit()
 }
 

--- a/.github/scripts/benchmark-watchdog.ps1
+++ b/.github/scripts/benchmark-watchdog.ps1
@@ -21,15 +21,22 @@ $exe = $Cmd[0]
 $cmdArgs = if ($Cmd.Count -gt 1) { $Cmd[1..($Cmd.Count-1)] } else { @() }
 
 Write-Host "--- $Name ---"
-if ($cmdArgs.Count -gt 0) {
-  $p = Start-Process -FilePath $exe -ArgumentList $cmdArgs -NoNewWindow -PassThru `
-       -RedirectStandardOutput $outFile -RedirectStandardError $errFile
-} else {
-  $p = Start-Process -FilePath $exe -NoNewWindow -PassThru `
-       -RedirectStandardOutput $outFile -RedirectStandardError $errFile
-}
+# Run through cmd.exe with shell redirection: unlike Start-Process handle
+# redirection, cmd's redirected handles are inherited by the whole process
+# tree, so the benchmark's own output (grandchild under withdll) is captured
+# too, not just withdll's banner.
+$quoted = @($exe) + $cmdArgs | ForEach-Object { '"' + $_ + '"' }
+$cmdLine = ($quoted -join ' ') + ' > "' + $outFile + '" 2> "' + $errFile + '"'
+$p = Start-Process -FilePath $env:ComSpec -ArgumentList @('/d', '/c', $cmdLine) `
+     -NoNewWindow -PassThru
 
 $finished = $p.WaitForExit($TimeoutSec * 1000)
+if ($finished) {
+  # Drain the process object: after a timed WaitForExit, .ExitCode is not
+  # populated until a final untimed WaitForExit() call. Without this the
+  # script exits with $null (= 0), masking benchmark crashes entirely.
+  $p.WaitForExit()
+}
 
 # Mirror benchmark output into the console and the aggregate log.
 $output = @()
@@ -42,8 +49,10 @@ if ($LogFile) {
 }
 
 if ($finished) {
-  Write-Host "$Name exited with $($p.ExitCode)"
-  exit $p.ExitCode
+  $code = $p.ExitCode
+  if ($null -eq $code) { $code = -1 }
+  Write-Host "$Name exited with $code"
+  exit $code
 }
 
 Write-Host "### $Name HUNG after ${TimeoutSec}s - capturing process-tree stacks ###"


### PR DESCRIPTION
Two watchdog defects (found while validating #101) that together made the Windows benchmark step **vacuously green** — including on master's current green run:

1. **Exit codes were swallowed**: after a timed `WaitForExit(ms)`, .NET does not populate `Process.ExitCode` until a final untimed `WaitForExit()`; `exit $p.ExitCode` was therefore `exit $null` (= 0) for every benchmark. A benchmark that crashed instantly still passed. Now drained properly, with null treated as failure.
2. **Grandchild output was lost**: `Start-Process` handle redirection captures only withdll's banner, not the benchmark's own stdout — which also blinded the "Check for crashes" grep. Now routed through `cmd.exe` shell redirection, whose handles the whole process tree inherits.

With this, green once again means: every benchmark ran, exited 0, and its self-reported results appear in the logs/artifacts. **This PR's own CI run re-validates master's Windows benchmarks with honest reporting.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)