### PR TITLE
Fix jemalloc/tcmalloc external-allocator builds so they actually intercept

### DIFF
--- a/allocators/CMakeLists.txt
+++ b/allocators/CMakeLists.txt
@@ -88,7 +88,12 @@ if(BUILD_JEMALLOC)
     GIT_SHALLOW       TRUE
     BUILD_IN_SOURCE   TRUE
     # jemalloc ships autogen.sh; run it, then configure with an install prefix.
+    # --with-jemalloc-prefix= (empty) makes jemalloc export plain malloc/free so
+    # it interposes the system allocator under LD_PRELOAD / DYLD_INSERT_LIBRARIES.
+    # (On macOS jemalloc otherwise defaults to a "je_" prefix and does NOT
+    # intercept; Linux already defaults to no prefix.)
     CONFIGURE_COMMAND ./autogen.sh --prefix=<INSTALL_DIR> --disable-debug
+                        --with-jemalloc-prefix=
     BUILD_COMMAND     make build_lib_shared -j
     INSTALL_COMMAND   make install_lib_shared install_include
     # Copy the resulting shared library into the common lib directory.
@@ -117,15 +122,14 @@ if(BUILD_TCMALLOC)
     GIT_SHALLOW       TRUE
     CMAKE_ARGS
       -DCMAKE_BUILD_TYPE=Release
-      -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
       -DBUILD_SHARED_LIBS=ON
       -DBUILD_TESTING=OFF
       -DGPERFTOOLS_BUILD_STATIC=OFF
       -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-    # Copy the minimal (malloc-only) shared library into the common lib dir.
-    INSTALL_COMMAND   ${CMAKE_COMMAND} --build . --target install
-    COMMAND           ${CMAKE_COMMAND} -E copy
-                        <INSTALL_DIR>/lib/${_tcmalloc_lib}
+    # gperftools' CMake build defines no install() rules; the shared library is
+    # produced directly in the build dir. Skip install and copy from there.
+    INSTALL_COMMAND   ${CMAKE_COMMAND} -E copy
+                        <BINARY_DIR>/${_tcmalloc_lib}
                         ${ALLOC_LIB_DIR}/${_tcmalloc_lib}
     LOG_CONFIGURE     TRUE
     LOG_BUILD         TRUE


### PR DESCRIPTION
## Summary

Follow-up to #104. Verifying the external-allocator builds end-to-end (full `-DBUILD_ALL_ALLOCATORS=ON` build + preload interception test on macOS arm64) surfaced two bugs that made two of the three allocators unusable.

## Bugs fixed

### tcmalloc — build failed at install
gperftools' CMake build defines **no `install()` rules**, so `cmake --build . --target install` failed with `No rule to make target 'install'`. The shared library is produced directly in the build dir, so copy it from `<BINARY_DIR>` and drop the unused `CMAKE_INSTALL_PREFIX`.

### jemalloc — built but did not intercept
On macOS jemalloc defaults to a `je_` symbol prefix, so the built dylib exported `_je_malloc` (not `_malloc`) and did **not** interpose the system allocator under `DYLD_INSERT_LIBRARIES`. Both a mach-zone probe and `MALLOC_CONF=stats_print:true` showed the system allocator still serving. Configure `--with-jemalloc-prefix=` (empty) so it exports plain `malloc`/`free`. Linux already defaults to no prefix.

## Verification (macOS, arm64)

All three now build, collect into `build/allocators/lib`, and **provably** intercept:

| allocator | interception evidence |
|-----------|----------------------|
| mimalloc  | registers named zone (`zone=mimalloc`) |
| jemalloc  | prints real `jemalloc statistics` (`Allocated: 292800...`) |
| tcmalloc  | prints `MALLOCSTATS` (`Bytes in use by application`) |

All three also run 4-thread `larson` correctly, each faster than the system baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)