### PR TITLE
Fix crash: pthread_create used a dead thread's TLAB on macOS

### DIFF
--- a/src/source/mactls.cpp
+++ b/src/source/mactls.cpp
@@ -195,8 +195,10 @@ extern "C" int xxpthread_create(pthread_t *thread,
                                 const pthread_attr_t *attr,
                                 void * (*start_routine)(void *),
                                 void * arg) {
-  // Force initialization of the TLAB before our first thread is created.
-  static TheCustomHeapType * t = getCustomHeap();
+  // Must be the *calling* thread's heap, fetched on every call: a static
+  // would pin every future pthread_create to the first creator's TLAB, which
+  // is destroyed when that thread exits (threads here spawn other threads).
+  TheCustomHeapType * t = getCustomHeap();
 
   anyThreadCreated = true;
 


### PR DESCRIPTION
## The bug

`xxpthread_create` (`src/source/mactls.cpp`) cached the custom heap in a function-local **static**:

```cpp
static TheCustomHeapType * t = getCustomHeap();
```

It is therefore initialized exactly once, by whichever thread first calls `pthread_create`, and every later call — from any thread — allocates the `(start_routine, arg)` pair from that one thread's TLAB.

When that first creator exits, `exitRoutine()` → `destroyThatHeap()` tears its TLAB down. From then on every `pthread_create` allocates from a **destroyed, recycled heap**, corrupting the freelist: `malloc` hands back a stale payload word as a `next` pointer and the placement-new writes through it.

This only bites when threads spawn threads, which is why the canonical larson run and most configs never trip it.

## Reproducer

A low `num_rounds` makes larson respawn threads constantly:

```
DYLD_INSERT_LIBRARIES=build/libhoard.dylib ./larson 5 7 8 1000 100 1 8
```

**5/5 runs crash** (SIGSEGV/SIGBUS). The faulting address is the address of larson's own thread entry point (`exercise_heap`) — i.e. the very function pointer this code stores at offset 0 of the pair, handed back by a corrupted freelist and written into read-only text (`EXC_BAD_ACCESS code=2`):

```
frame #0: libhoard.dylib`xxpthread_create + 148
frame #1: larson`_beginthread at larson.cpp:88
frame #2: larson`exercise_heap at larson.cpp:601
frame #3: libhoard.dylib`startMeUp
```

## The fix

Fetch the **calling** thread's heap on every call. This still forces TLAB initialization (`getCustomHeap()` initializes on first use per thread) and costs only a TLS read. The Linux path (`unixtls.cpp`) was never affected — it allocates on the calling thread already.

## Verification

- Crashing config: **5/5 crashes before → 0/10 after**.
- Sweep of 11 configs (7 respawn-heavy, plus canonical and wide-size-range runs as a regression check): all green.
- No perf cost: canonical `larson 5 7 8 1000 10000 1 8` at 384M ops/s, at the top of the 330–360M band documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)