### PR TITLE
CI: larson QoS gate vs mimalloc/jemalloc

### DIFF
--- a/.github/workflows/qos-larson.yml
+++ b/.github/workflows/qos-larson.yml
@@ -1,0 +1,84 @@
+name: Larson QoS
+
+# Performance gate: Hoard must stay within a set fraction of mimalloc's larson
+# throughput. Allocators are all measured in the SAME job on the SAME runner and
+# compared as a RATIO, which cancels most of the (large) speed variation between
+# CI runners -- an absolute ops/sec threshold would either flake constantly or be
+# too loose to catch anything. See scripts/qos_larson.py.
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch:
+    inputs:
+      report_only:
+        description: "Measure and report without failing (used to calibrate the floor)"
+        type: boolean
+        default: false
+
+jobs:
+  qos-larson:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y cmake build-essential autoconf
+
+      - name: Build Hoard and the comparison allocators
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release \
+                -DBUILD_MIMALLOC=ON -DBUILD_JEMALLOC=ON
+          cmake --build build -j$(getconf _NPROCESSORS_ONLN)
+
+      - name: Build larson
+        run: c++ -O2 -o larson_bin benchmarks/larson/larson.cpp -lpthread
+
+      - name: Locate allocator libraries
+        id: libs
+        run: |
+          set -e
+          if [ "${{ runner.os }}" = "macOS" ]; then EXT=dylib; else EXT=so; fi
+          HOARD=$(ls build/libhoard.$EXT)
+          # Version suffixes differ by platform (libmimalloc.2.dylib,
+          # libmimalloc.so.2.x); take the first match and let the script's
+          # interposition check catch anything wrong.
+          MI=$(ls build/allocators/lib/libmimalloc*.$EXT* | head -1)
+          JE=$(ls build/allocators/lib/libjemalloc*.$EXT* | head -1)
+          for f in "$HOARD" "$MI" "$JE"; do
+            [ -e "$f" ] || { echo "missing allocator library: $f"; exit 1; }
+          done
+          echo "hoard=$PWD/$HOARD"    >> $GITHUB_OUTPUT
+          echo "mimalloc=$PWD/$MI"    >> $GITHUB_OUTPUT
+          echo "jemalloc=$PWD/$JE"    >> $GITHUB_OUTPUT
+
+      - name: Larson QoS gate
+        run: |
+          # MIN_RATIO is the floor for hoard/mimalloc. It is set from measured
+          # runner variance -- see the calibration note in scripts/qos_larson.py.
+          # 0 disables gating (report-only).
+          MIN_RATIO=0
+          REPORT_ONLY="--report-only"
+          python3 scripts/qos_larson.py \
+            --larson "$PWD/larson_bin" \
+            --hoard "${{ steps.libs.outputs.hoard }}" \
+            --mimalloc "${{ steps.libs.outputs.mimalloc }}" \
+            --jemalloc "${{ steps.libs.outputs.jemalloc }}" \
+            --threads 1,4 --reps 5 --sleep 3 \
+            --min-ratio $MIN_RATIO $REPORT_ONLY \
+            --json qos-${{ matrix.os }}.json
+
+      - name: Upload QoS results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qos-larson-${{ matrix.os }}
+          path: qos-${{ matrix.os }}.json

--- a/.github/workflows/qos-larson.yml
+++ b/.github/workflows/qos-larson.yml
@@ -67,18 +67,21 @@ jobs:
 
       - name: Larson QoS gate
         run: |
-          # MIN_RATIO is the floor for hoard/mimalloc. It is set from measured
-          # runner variance -- see the calibration note in scripts/qos_larson.py.
-          # 0 disables gating (report-only).
-          MIN_RATIO=0
-          REPORT_ONLY="--report-only"
+          # Floor for hoard/mimalloc, calibrated from measured runner variance
+          # (see the calibration note in scripts/qos_larson.py). Observed:
+          #   ubuntu  1t 0.84-0.90  4t 0.94-0.97
+          #   macos   1t 0.93-1.03  4t 0.96-1.12  (shared runners, ~0.1 swing)
+          # 0.75 sits clear of that noise and still trips on a ~17% regression.
+          # --retry-on-fail re-measures before failing, so a one-off dip from a
+          # noisy neighbour cannot break the build on its own.
           python3 scripts/qos_larson.py \
             --larson "$PWD/larson_bin" \
             --hoard "${{ steps.libs.outputs.hoard }}" \
             --mimalloc "${{ steps.libs.outputs.mimalloc }}" \
             --jemalloc "${{ steps.libs.outputs.jemalloc }}" \
             --threads 1,4 --reps 5 --sleep 3 \
-            --min-ratio $MIN_RATIO $REPORT_ONLY \
+            --min-ratio 0.75 --retry-on-fail \
+            ${{ inputs.report_only && '--report-only' || '' }} \
             --json qos-${{ matrix.os }}.json
 
       - name: Upload QoS results

--- a/.github/workflows/qos-larson.yml
+++ b/.github/workflows/qos-larson.yml
@@ -33,6 +33,11 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y cmake build-essential autoconf
 
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        # jemalloc builds via autogen.sh, which needs autoconf.
+        run: brew install autoconf automake
+
       - name: Build Hoard and the comparison allocators
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/qos_larson.py
+++ b/scripts/qos_larson.py
@@ -22,6 +22,26 @@ outlier a shared runner will produce.
 Interposition is VERIFIED, not assumed: a silently-not-preloaded library just
 measures the system allocator, which would make the gate meaningless (and on
 macOS, SIP strips DYLD_INSERT_LIBRARIES from system binaries -- see CLAUDE.md).
+
+CALIBRATING --min-ratio
+-----------------------
+The floor is set from MEASURED runner variance, not guessed. Observed
+hoard/mimalloc across repeated CI runs (report-only, reps=5):
+
+    ubuntu-latest (4 cpu, x86_64):  1t 0.84-0.90    4t 0.94-0.97
+    macos-latest  (3 cpu, arm64):   1t 0.93-1.03    4t 0.96-1.12
+
+Linux is fairly tight. The macOS runners are shared and genuinely noisy: the
+RATIO itself swings by ~0.1 between runs, with up to 35% min-max spread within
+a single config. So the floor has to sit well below the worst observed value
+(0.84), which is why it is 0.75 rather than something snug like 0.80 -- a gate
+that flakes gets ignored, and an ignored gate is worse than none.
+
+On top of that, --retry-on-fail re-measures from scratch before failing, so a
+one-off noise dip has to happen twice independently to break the build. That is
+what buys the gate its sensitivity: it reliably catches a real regression
+(Hoard currently sits at ~0.9x mimalloc, so 0.75 trips on roughly a 17% drop)
+without failing on runner noise.
 """
 
 import argparse
@@ -101,6 +121,8 @@ def main():
     p.add_argument("--sleep", type=int, default=3, help="larson run seconds")
     p.add_argument("--min-ratio", type=float, default=0.0,
                    help="fail if hoard_median < min-ratio * mimalloc_median")
+    p.add_argument("--retry-on-fail", action="store_true",
+                   help="re-measure once before failing, to reject runner noise")
     p.add_argument("--report-only", action="store_true",
                    help="measure and report, never fail (used to calibrate)")
     p.add_argument("--json", default=None, help="write results here")
@@ -119,60 +141,74 @@ def main():
         verify_interposition(args.larson, lib, name)
     print()
 
-    results = {}
-    for nthreads in [int(t) for t in args.threads.split(",")]:
-        # mimalloc-bench canonical larson parameters.
-        largs = [args.sleep, 7, 8, 1000, 10000, 1, nthreads]
-        cfg = f"{nthreads}t"
-        runs = {name: [] for name, _ in allocators}
+    def measure_and_report(label=""):
+        """One full interleaved measurement pass. Returns (results, failures)."""
+        results = {}
+        for nthreads in [int(t) for t in args.threads.split(",")]:
+            # mimalloc-bench canonical larson parameters.
+            largs = [args.sleep, 7, 8, 1000, 10000, 1, nthreads]
+            cfg = f"{nthreads}t"
+            runs = {name: [] for name, _ in allocators}
 
-        # Interleaved: rep-major, so runner drift hits all allocators equally.
-        for _rep in range(args.reps):
-            for name, lib in allocators:
-                runs[name].append(run_larson(args.larson, largs, lib))
+            # Interleaved: rep-major, so runner drift hits all allocators equally.
+            for _rep in range(args.reps):
+                for name, lib in allocators:
+                    runs[name].append(run_larson(args.larson, largs, lib))
 
-        results[cfg] = {n: {"runs": r, "median": statistics.median(r)}
-                        for n, r in runs.items()}
+            results[cfg] = {n: {"runs": r, "median": statistics.median(r)}
+                            for n, r in runs.items()}
 
-    # ---- report ----
-    print(f"larson <sleep> 7 8 1000 10000 1 <threads>, "
-          f"median of {args.reps} interleaved runs (Mops/sec)\n")
-    hdr = f"{'config':>8}  " + "".join(f"{n:>12}" for n, _ in allocators) + \
-          f"{'hoard/mi':>11}{'hoard/je':>11}"
-    print(hdr)
-    print("-" * len(hdr))
+        print(f"{label}larson <sleep> 7 8 1000 10000 1 <threads>, "
+              f"median of {args.reps} interleaved runs (Mops/sec)\n")
+        hdr = f"{'config':>8}  " + "".join(f"{n:>12}" for n, _ in allocators) + \
+              f"{'hoard/mi':>11}{'hoard/je':>11}"
+        print(hdr)
+        print("-" * len(hdr))
 
-    failures = []
-    for cfg, res in results.items():
-        h = res["hoard"]["median"]
-        mi = res["mimalloc"]["median"]
-        je = res.get("jemalloc", {}).get("median")
-        row = f"{cfg:>8}  " + "".join(
-            f"{res[n]['median']/1e6:>12.1f}" for n, _ in allocators)
-        r_mi = h / mi if mi else float("nan")
-        row += f"{r_mi:>11.2f}"
-        row += f"{h/je:>11.2f}" if je else f"{'-':>11}"
-        print(row)
-        if args.min_ratio and r_mi < args.min_ratio:
-            failures.append((cfg, r_mi))
+        failures = []
+        for cfg, res in results.items():
+            h = res["hoard"]["median"]
+            mi = res["mimalloc"]["median"]
+            je = res.get("jemalloc", {}).get("median")
+            row = f"{cfg:>8}  " + "".join(
+                f"{res[n]['median']/1e6:>12.1f}" for n, _ in allocators)
+            r_mi = h / mi if mi else float("nan")
+            row += f"{r_mi:>11.2f}"
+            row += f"{h/je:>11.2f}" if je else f"{'-':>11}"
+            print(row)
+            if args.min_ratio and r_mi < args.min_ratio:
+                failures.append((cfg, r_mi))
 
-    # Spread, so a noisy runner is visible rather than silently shifting a median.
-    print("\nspread (min-max as % of median):")
-    for cfg, res in results.items():
-        parts = []
-        for name, _ in allocators:
-            r = res[name]["runs"]
-            med = res[name]["median"]
-            parts.append(f"{name} {100*(max(r)-min(r))/med:.0f}%")
-        print(f"  {cfg:>8}  " + "  ".join(parts))
+        # Spread, so a noisy runner is visible rather than silently shifting a median.
+        print("\nspread (min-max as % of median):")
+        for cfg, res in results.items():
+            parts = []
+            for name, _ in allocators:
+                r = res[name]["runs"]
+                med = res[name]["median"]
+                parts.append(f"{name} {100*(max(r)-min(r))/med:.0f}%")
+            print(f"  {cfg:>8}  " + "  ".join(parts))
+        print()
+        return results, failures
 
-    if args.json:
-        with open(args.json, "w") as f:
-            json.dump({"platform": platform.system(),
-                       "machine": platform.machine(),
-                       "cpus": os.cpu_count(),
-                       "min_ratio": args.min_ratio,
-                       "results": results}, f, indent=2)
+    results, failures = measure_and_report()
+
+    # Confirm before failing: CI runners are noisy enough (see the calibration
+    # note above) that a single dip below the floor is more likely to be a noisy
+    # neighbour than a real regression. Re-measure from scratch and fail only if
+    # it reproduces -- a flaky gate gets ignored, and an ignored gate is useless.
+    if failures and args.retry_on_fail and not args.report_only:
+        print(f"below the {args.min_ratio:.2f}x floor on "
+              f"{', '.join(c for c, _ in failures)}; re-measuring to confirm "
+              f"(this is noise-rejection, not a retry until green)...\n")
+        results2, failures2 = measure_and_report(label="CONFIRMATION PASS: ")
+        confirmed = {c for c, _ in failures} & {c for c, _ in failures2}
+        if not confirmed:
+            print("Did not reproduce: treating the first pass as runner noise.")
+            failures = []
+        else:
+            failures = [f for f in failures2 if f[0] in confirmed]
+            results = results2
 
     print()
     if args.report_only:

--- a/scripts/qos_larson.py
+++ b/scripts/qos_larson.py
@@ -159,9 +159,13 @@ def main():
                             for n, r in runs.items()}
 
         print(f"{label}larson <sleep> 7 8 1000 10000 1 <threads>, "
-              f"median of {args.reps} interleaved runs (Mops/sec)\n")
-        hdr = f"{'config':>8}  " + "".join(f"{n:>12}" for n, _ in allocators) + \
-              f"{'hoard/mi':>11}{'hoard/je':>11}"
+              f"median of {args.reps} interleaved runs.")
+        print("Throughput in Mops/sec: HIGHER IS BETTER.")
+        print("The last two columns are how many times FASTER Hoard is than "
+              "that allocator:\n  >1.00 = Hoard wins, <1.00 = Hoard loses "
+              "(flagged SLOWER).\n")
+        hdr = (f"{'config':>8}  " + "".join(f"{n:>12}" for n, _ in allocators)
+               + f"{'vs mimalloc':>14}{'vs jemalloc':>14}")
         print(hdr)
         print("-" * len(hdr))
 
@@ -172,9 +176,16 @@ def main():
             je = res.get("jemalloc", {}).get("median")
             row = f"{cfg:>8}  " + "".join(
                 f"{res[n]['median']/1e6:>12.1f}" for n, _ in allocators)
+
+            def fmt_ratio(r):
+                # Spell out the direction: a bare "0.82" reads as fine until you
+                # remember higher-is-better. Mark the losses -- but judge on the
+                # DISPLAYED value, so 0.996 does not print "1.00x SLOWER".
+                return f"{r:.2f}x" + (" SLOWER" if round(r, 2) < 1.0 else "")
+
             r_mi = h / mi if mi else float("nan")
-            row += f"{r_mi:>11.2f}"
-            row += f"{h/je:>11.2f}" if je else f"{'-':>11}"
+            row += f"{fmt_ratio(r_mi):>14}"
+            row += f"{fmt_ratio(h/je):>14}" if je else f"{'-':>14}"
             print(row)
             if args.min_ratio and r_mi < args.min_ratio:
                 failures.append((cfg, r_mi))

--- a/scripts/qos_larson.py
+++ b/scripts/qos_larson.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Larson QoS gate: compare Hoard's throughput against mimalloc and jemalloc.
+
+Used both as a local benchmark and as a CI gate.
+
+WHY A RATIO, NOT AN ABSOLUTE NUMBER
+-----------------------------------
+CI runners vary enormously in absolute speed (shared hardware, different
+generations, noisy neighbours), so an absolute ops/sec threshold would either
+flake constantly or be so loose it catches nothing. Every allocator is measured
+in the SAME job on the SAME runner and Hoard is scored as a ratio to mimalloc,
+which cancels most of that variation. The gate fails only if Hoard drops below
+--min-ratio of mimalloc.
+
+Runs are interleaved (round-robin over allocators, repeated) rather than
+batched per allocator, so a runner that slows down partway through penalises
+every allocator equally instead of whichever one happened to run last. Each
+allocator's score is the MEDIAN of its runs, which ignores the occasional
+outlier a shared runner will produce.
+
+Interposition is VERIFIED, not assumed: a silently-not-preloaded library just
+measures the system allocator, which would make the gate meaningless (and on
+macOS, SIP strips DYLD_INSERT_LIBRARIES from system binaries -- see CLAUDE.md).
+"""
+
+import argparse
+import json
+import os
+import platform
+import re
+import statistics
+import subprocess
+import sys
+
+IS_MAC = platform.system() == "Darwin"
+PRELOAD_VAR = "DYLD_INSERT_LIBRARIES" if IS_MAC else "LD_PRELOAD"
+
+THROUGHPUT_RE = re.compile(r"Throughput\s*=\s*([0-9]+)")
+
+
+def run_larson(larson, args, lib):
+    """One larson run under `lib` (None = system allocator). Returns ops/sec."""
+    env = dict(os.environ)
+    if lib:
+        env[PRELOAD_VAR] = lib
+    proc = subprocess.run([larson] + [str(a) for a in args],
+                          env=env, capture_output=True, text=True, timeout=600)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"larson exited {proc.returncode} under {lib or 'system'}\n"
+            f"stdout:\n{proc.stdout[-2000:]}\nstderr:\n{proc.stderr[-2000:]}")
+    m = THROUGHPUT_RE.search(proc.stdout)
+    if not m:
+        raise RuntimeError(
+            f"no Throughput line under {lib or 'system'}:\n{proc.stdout[-2000:]}")
+    return int(m.group(1))
+
+
+def verify_interposition(larson, lib, name):
+    """Fail loudly if `lib` is not actually being loaded.
+
+    A preload that silently does nothing measures the system allocator and
+    would make every number here a lie.
+    """
+    env = dict(os.environ)
+    env[PRELOAD_VAR] = lib
+    if IS_MAC:
+        env["DYLD_PRINT_LIBRARIES"] = "1"
+    # A trivial run: 1 thread, tiny workload.
+    proc = subprocess.run([larson, "1", "7", "8", "100", "1000", "1", "1"],
+                          env=env, capture_output=True, text=True, timeout=300)
+    err = proc.stderr
+    if IS_MAC:
+        # dyld prints the RESOLVED path, so libmimalloc.2.dylib (a symlink)
+        # shows up as libmimalloc.2.1.dylib. Match the library stem.
+        stem = re.match(r"(lib[a-zA-Z0-9_]+)", os.path.basename(lib))
+        stem = stem.group(1) if stem else os.path.basename(lib)
+        loaded = stem in err
+    else:
+        # glibc prints "cannot be preloaded" and carries on with the system
+        # allocator; absence of that message means the preload took.
+        loaded = "cannot be preloaded" not in err and proc.returncode == 0
+    if not loaded:
+        print(f"ERROR: {name} ({lib}) is NOT being interposed.", file=sys.stderr)
+        print(f"stderr:\n{err[-2000:]}", file=sys.stderr)
+        sys.exit(2)
+    print(f"  interposition OK: {name}")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--larson", required=True, help="path to the larson binary")
+    p.add_argument("--hoard", required=True)
+    p.add_argument("--mimalloc", required=True)
+    p.add_argument("--jemalloc", default=None)
+    p.add_argument("--reps", type=int, default=5,
+                   help="runs per allocator per config (median is scored)")
+    p.add_argument("--threads", default="1,4",
+                   help="comma-separated thread counts to test")
+    p.add_argument("--sleep", type=int, default=3, help="larson run seconds")
+    p.add_argument("--min-ratio", type=float, default=0.0,
+                   help="fail if hoard_median < min-ratio * mimalloc_median")
+    p.add_argument("--report-only", action="store_true",
+                   help="measure and report, never fail (used to calibrate)")
+    p.add_argument("--json", default=None, help="write results here")
+    args = p.parse_args()
+
+    allocators = [("hoard", args.hoard), ("mimalloc", args.mimalloc)]
+    if args.jemalloc:
+        allocators.append(("jemalloc", args.jemalloc))
+
+    print(f"Larson QoS ({platform.system()} {platform.machine()}, "
+          f"{os.cpu_count()} cpus, {PRELOAD_VAR})")
+    for name, lib in allocators:
+        if not os.path.exists(lib):
+            print(f"ERROR: {name} library not found: {lib}", file=sys.stderr)
+            sys.exit(2)
+        verify_interposition(args.larson, lib, name)
+    print()
+
+    results = {}
+    for nthreads in [int(t) for t in args.threads.split(",")]:
+        # mimalloc-bench canonical larson parameters.
+        largs = [args.sleep, 7, 8, 1000, 10000, 1, nthreads]
+        cfg = f"{nthreads}t"
+        runs = {name: [] for name, _ in allocators}
+
+        # Interleaved: rep-major, so runner drift hits all allocators equally.
+        for _rep in range(args.reps):
+            for name, lib in allocators:
+                runs[name].append(run_larson(args.larson, largs, lib))
+
+        results[cfg] = {n: {"runs": r, "median": statistics.median(r)}
+                        for n, r in runs.items()}
+
+    # ---- report ----
+    print(f"larson <sleep> 7 8 1000 10000 1 <threads>, "
+          f"median of {args.reps} interleaved runs (Mops/sec)\n")
+    hdr = f"{'config':>8}  " + "".join(f"{n:>12}" for n, _ in allocators) + \
+          f"{'hoard/mi':>11}{'hoard/je':>11}"
+    print(hdr)
+    print("-" * len(hdr))
+
+    failures = []
+    for cfg, res in results.items():
+        h = res["hoard"]["median"]
+        mi = res["mimalloc"]["median"]
+        je = res.get("jemalloc", {}).get("median")
+        row = f"{cfg:>8}  " + "".join(
+            f"{res[n]['median']/1e6:>12.1f}" for n, _ in allocators)
+        r_mi = h / mi if mi else float("nan")
+        row += f"{r_mi:>11.2f}"
+        row += f"{h/je:>11.2f}" if je else f"{'-':>11}"
+        print(row)
+        if args.min_ratio and r_mi < args.min_ratio:
+            failures.append((cfg, r_mi))
+
+    # Spread, so a noisy runner is visible rather than silently shifting a median.
+    print("\nspread (min-max as % of median):")
+    for cfg, res in results.items():
+        parts = []
+        for name, _ in allocators:
+            r = res[name]["runs"]
+            med = res[name]["median"]
+            parts.append(f"{name} {100*(max(r)-min(r))/med:.0f}%")
+        print(f"  {cfg:>8}  " + "  ".join(parts))
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump({"platform": platform.system(),
+                       "machine": platform.machine(),
+                       "cpus": os.cpu_count(),
+                       "min_ratio": args.min_ratio,
+                       "results": results}, f, indent=2)
+
+    print()
+    if args.report_only:
+        print("report-only: not gating.")
+        return 0
+    if failures:
+        for cfg, r in failures:
+            print(f"FAIL: {cfg}: hoard is {r:.2f}x mimalloc, "
+                  f"below the {args.min_ratio:.2f}x floor", file=sys.stderr)
+        return 1
+    if args.min_ratio:
+        print(f"PASS: hoard >= {args.min_ratio:.2f}x mimalloc on all configs.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a larson performance gate against mimalloc and jemalloc, plus the harness (`scripts/qos_larson.py`) which doubles as a local benchmark.

## Numbers

**Local (M1 Max, 10 cores)** — median of 5 interleaved runs, Mops/sec:

| threads | hoard | mimalloc | jemalloc | hoard/mi | hoard/je |
|---|---|---|---|---|---|
| 1 | 65.2 | 66.3 | 34.5 | 0.98 | 1.89 |
| 2 | 107.9 | 114.7 | 60.1 | 0.94 | 1.80 |
| 4 | 218.5 | 223.1 | 116.3 | 0.98 | 1.88 |
| 8 | 365.3 | 363.4 | 187.1 | 1.01 | 1.95 |

**CI** (from the gating run on this PR):

| runner | threads | hoard | mimalloc | jemalloc | hoard/mi | hoard/je |
|---|---|---|---|---|---|---|
| macos-latest (3 cpu, arm64) | 1 | 58.3 | 62.2 | 30.1 | 0.94 | 1.94 |
| macos-latest | 4 | 170.4 | 183.2 | 91.9 | 0.93 | 1.85 |
| ubuntu-latest (4 cpu, x86_64) | 1 | 38.8 | 46.1 | 47.2 | 0.84 | 0.82 |
| ubuntu-latest | 4 | 113.5 | 119.3 | 87.8 | 0.95 | 1.29 |

Hoard is at rough parity with mimalloc (0.84–1.01) and ~1.8–1.9x jemalloc on arm64. Worth noting: on **x86_64 Linux, jemalloc beats Hoard single-threaded** (0.82) — that's the weakest spot in this data, consistent with CLAUDE.md's note about raw fast-path length.

## Gate design

- **Ratio, not absolute.** All allocators run in the same job on the same runner; Hoard is scored against mimalloc. Runner speed varies too much for an ops/sec threshold to mean anything.
- **Interleaved + median.** Round-robin over allocators, repeated, so mid-run drift penalises everyone equally and outliers don't move the score.
- **Interposition verified, not assumed.** A preload that silently doesn't take just measures the system allocator and makes every number a lie (CLAUDE.md's SIP warning).
- **Floor calibrated from measured variance, not guessed.** I ran it report-only across repeated CI runs first:

  | | 1t | 4t |
  |---|---|---|
  | ubuntu-latest | 0.84–0.90 | 0.94–0.97 |
  | macos-latest | 0.93–1.03 | 0.96–1.12 |

  Linux is tight. The macOS runners are shared and genuinely noisy — the *ratio* swings ~0.1 between runs, with up to 35% min-max spread inside one config. So the floor is **0.75**, clear of that noise rather than snug against the worst observed value (0.84). A gate that flakes gets ignored, and an ignored gate is worse than none.
- **Noise rejection.** `--retry-on-fail` re-measures from scratch and fails only if the shortfall reproduces, so one noisy neighbour can't break the build. That's what buys sensitivity back: Hoard sits at ~0.9x, so 0.75 trips on roughly a **17% regression**.

Verified in both directions: passes on the current tree, and exits 1 (after a confirmation pass) when handed a deliberately slow allocator.

## Cost

~6–9 min per runner, in its own workflow so it doesn't slow the build/crash gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)