### PR TITLE
Define the ownership bitmap in the header on ELF (unbreaks header-only consumers)

### DIFF
--- a/src/include/util/ownershipmap.h
+++ b/src/include/util/ownershipmap.h
@@ -69,8 +69,27 @@ namespace Hoard {
     // zerofill with no constructor.
     constexpr size_t kChunkSize = 262144;
     constexpr size_t kNumWords = (1ULL << 48) / kChunkSize / 64;
+
+#if defined(__APPLE__)
+    // Mach-O: declared here, DEFINED in libhoard.cpp (see the note above --
+    // a weak/coalesced 128MB symbol cannot land in a zerofill section here).
     extern __attribute__((visibility("hidden")))
     uint64_t bits[kNumWords];
+#else
+    // ELF: define the storage right here as an inline variable. It is a
+    // plain integer array with no initializer, so it lands in .bss (zerofill,
+    // no file-size cost) and COMDAT-dedupes to one copy per shared object.
+    //
+    // This must NOT be confined to libhoard.cpp: alignedmmap.h calls
+    // OwnershipMap::set() unconditionally, so ANY consumer that builds Hoard's
+    // heaps from these headers without also compiling libhoard.cpp (alloc8's
+    // examples/hoard does exactly that) would otherwise fail to link with
+    // "undefined reference to Hoard::ownershipdetail::bits" -- and, because
+    // the symbol is hidden, it cannot be satisfied from another shared object
+    // either. Defining it in the header keeps such consumers working.
+    inline __attribute__((visibility("hidden")))
+    uint64_t bits[kNumWords];
+#endif
 
     using AtomicWord = std::atomic_ref<uint64_t>;
     static_assert (alignof(uint64_t) >= AtomicWord::required_alignment,

--- a/src/source/libhoard.cpp
+++ b/src/source/libhoard.cpp
@@ -172,11 +172,15 @@ extern bool isCustomHeapInitialized();
 // resident memory. A plain integer array has no constructor to run, so it
 // lands in zerofill at every optimization level; constinit enforces that
 // at compile time rather than leaving it to the optimizer.
+#if defined(__APPLE__)
+// Mach-O only: on ELF the storage is an inline variable in ownershipmap.h, so
+// that consumers building Hoard's heaps from the headers alone still link.
 namespace Hoard {
   namespace ownershipdetail {
     constinit uint64_t bits[kNumWords] = {};
   }
 }
+#endif
 #endif
 
 #include "wrappers/generic-memalign.cpp"


### PR DESCRIPTION
Fixes a downstream breakage that my recent merges exposed.

## The bug

`alignedmmap.h` calls `OwnershipMap::set()` unconditionally, but the storage for `Hoard::ownershipdetail::bits` was defined **only in `libhoard.cpp`**. So any consumer that builds Hoard's heaps from the headers *without also compiling `libhoard.cpp`* fails to link:

```
undefined reference to `Hoard::ownershipdetail::bits'
relocation R_X86_64_PC32 against undefined hidden symbol ... can not be used
when making a shared object
```

and because the symbol is **hidden**, it can't be satisfied from another shared object either.

**alloc8's `examples/hoard` does exactly this** — it's a header-only mini-`libhoard.cpp` that supplies its own `xx*` entry points. It is currently broken on ELF against Hoard master. I confirmed this is not hypothetical by re-running alloc8's CI on an **unmodified `main`**: `build-linux-hoard` and `build-linux-arm64-hoard` both fail.

## The fix

On **ELF**, define the storage as an `inline` variable in the header. It's a plain integer array with no initializer, so it lands in `.bss` (zerofill, no file-size cost) and COMDAT-dedupes to one copy per shared object.

On **Mach-O**, keep the `libhoard.cpp` definition. A weak/coalesced 128MB symbol cannot land in a zerofill section there and would bloat the dylib by the full 128MB — the constraint already documented in CLAUDE.md.

## Verified

| | result |
|---|---|
| `libhoard.so` (ELF) | builds, **555KB** (no bloat), exactly **1** definition of the symbol |
| `libhoard.dylib` (Mach-O) | unchanged, **1.66MB**, still a single `__DATA,__common` definition |
| Hoard runtime | larson clean on both platforms |
| alloc8 `examples/hoard` | **links again** on ELF |

🤖 Generated with [Claude Code](https://claude.com/claude-code)