### PR TITLE
Opt out of alloc8's caller-RA hint (~15% of the allocation fast path)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,14 @@ Globals that Hoard's own entry points touch **must be constant-initialized** —
 
 This bit the ownership bitmap (`ownershipmap.h` / `libhoard.cpp`): an array of `std::atomic<uint64_t>` **cannot** be constant-initialized with libc++ (its default constructor is not usable in a constant expression), so unoptimized builds emitted a dynamic initializer that walked all 2^24 elements at load and zeroed the map, wiping the ownership bits of every superblock mapped during startup. alloc8 then saw those pointers as foreign and misrouted their `free`/`malloc_size` (objc aborted with "corrupt data pointer"; `malloc_size` returned 0). Optimized builds constant-folded it to zerofill and were unaffected — an optimization-level-dependent miscompile of the invariant. The storage is now a plain `uint64_t` array (no constructor, always zerofill) accessed via `std::atomic_ref`, marked `constinit` so the compiler enforces it. It would also have touched all 128MB, turning reserved address space into resident memory.
 
+### Interposition-layer overhead (alloc8)
+
+Hoard's fast path is only as short as alloc8's entry points, which sit in front of every `malloc`/`free`. Measured on a tight recycle loop (M1 Max), alloc8's per-op entry work was **~36% of the whole allocation fast path**. It is now one acquire load (`g_fast` in alloc8) gating init, passthrough and stats together, and Hoard compiles with `-DALLOC8_NO_CALLER_RA` (CMakeLists.txt) because it never reads alloc8's caller-return-address hint — a `thread_local` store that cost ~15% on its own.
+
+Do NOT relax alloc8's `ensure_init` acquire load to relaxed (worth another ~12%): dyld constructors can allocate from several threads before alloc8's priority-101 init runs — that is why `alloc8_init_once` has a spin-wait — and a relaxed load could observe `INIT_DONE` without the values it publishes.
+
+If a change to the fast path shows no benefit, check whether alloc8 is the bottleneck before optimizing Hoard: the *bulk* gap is Hoard's (locks and per-object bookkeeping), but the *recycle* gap was alloc8's.
+
 ### Baseline Comparisons
 
 When optimizing, compare against mimalloc and jemalloc, not system malloc. Use consistent benchmark parameters across runs. Larson is sensitive to cross-thread free patterns; threadtest measures pure per-thread throughput.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,12 @@ set(WINDOWS_SOURCES
   ${ALLOC8_INTERPOSE_SOURCES}
 )
 
+# Hoard never reads alloc8's caller-return-address hint (alloc8_caller_ra), and
+# it is a thread_local store on EVERY malloc and free -- ~15% of the allocation
+# fast path. Opt out of it. (Harmlessly ignored by alloc8 versions that predate
+# the flag; the symbol is still defined either way.)
+add_definitions(-DALLOC8_NO_CALLER_RA)
+
 if(WIN32)
   #
   # ─── WINDOWS BUILD ───────────────────────────────────────────────────


### PR DESCRIPTION
Pairs with **emeryberger/alloc8#13** (merged). Together these close most of the remaining fast-path gap to mimalloc.

## What was costing us

alloc8's entry points sit in front of every `malloc`/`free`, and each one did **three separate per-op checks** plus a `thread_local` store of the caller return address — which **nothing ever reads**.

Measured on a tight recycle loop (M1 Max), that entry work was **~36% of Hoard's entire allocation fast path**:

| | ns/op | saving |
|---|---|---|
| baseline | 3.95 | — |
| minus caller-RA store | 3.34 | **15%** |
| `ensure_init` acquire → relaxed | 3.46 | 12% |
| minus stats `bump` | 3.65 | 8% |
| all three | 2.53 | 36% |

## The fix

- **alloc8#13** folds init + passthrough + stats into a **single acquire load**, and adds `ALLOC8_NO_CALLER_RA`.
- **This PR** defines `ALLOC8_NO_CALLER_RA`, since Hoard never reads `alloc8_caller_ra`.

Deliberately **not** done: relaxing alloc8's `ensure_init` acquire load (another ~12%). dyld constructors can allocate from several threads before alloc8's priority-101 init runs — that's why `alloc8_init_once` has a spin-wait — and a relaxed load could observe `INIT_DONE` without the values it publishes.

## Result (macOS arm64)

| | before | after | mimalloc |
|---|---|---|---|
| recycle fast path | 4.04 ns/op | **2.75** | 2.07 |
| linux-scalability | 0.255 s | **0.223** | 0.124 |
| larson, 1 thread | 1.00x mimalloc | **1.05x** (ahead) | — |
| larson, 8 threads | 0.91x mimalloc | **1.00x** (+9.7%) | — |

Recycle goes from **1.89x → 1.33x** of mimalloc.

## Verified

- Alignment, `malloc_size`, larson to 32 threads, full mimalloc-bench-style suite (11/11) — all clean.
- `ALLOC8_STATS` still counts every allocation (200000 mallocs / 199995 frees), now via alloc8's slow path.

## Corrected note in CLAUDE.md

I previously concluded the data "exonerated alloc8". That was right for the **bulk** gap (locks and per-object bookkeeping — Hoard's own), but **wrong** for the **recycle** gap, which was alloc8's. CLAUDE.md now says so, so the next person checks the interposition layer before optimizing the allocator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)