### PR TITLE
Remove `#define inline __forceinline` (the Windows data-declaration trap)

### DIFF
--- a/src/source/libhoard.cpp
+++ b/src/source/libhoard.cpp
@@ -50,8 +50,21 @@
 // Maximize the degree of inlining.
 #pragma inline_depth(255)
 
-// Turn inlining hints into requirements.
-#define inline __forceinline
+// NOTE: do NOT `#define inline __forceinline` here.
+//
+// It was legacy and redundant -- Heap-Layers already maps INLINE to
+// __forceinline on MSVC (and has its own copy of this #define commented out),
+// and every hot path force-inlines explicitly (INLINE, TLAB_ALWAYS_INLINE, or
+// a bare __forceinline). What the macro DID do was rewrite `inline` on *data*
+// declarations, which MSVC rejects outright:
+//
+//   error C2433: '__forceinline' not permitted on data declarations
+//
+// so no header reachable from here could use a C++17 `inline` variable or a
+// `static inline` member. That trap cost three separate build breakages
+// (ownershipmap.h's bitmap, sizeclasses.h's tables, shardedglobalheap.h's
+// retain counter), each caught only by Windows CI. Removing it lets headers
+// use ordinary modern C++.
 #pragma warning(disable:4273)
 #pragma warning(disable: 4098)  // Library conflict.
 #pragma warning(disable: 4355)  // 'this' used in base member initializer list.


### PR DESCRIPTION
Kills the trap at the root instead of working around it a fourth time.

## What it was doing

`libhoard.cpp` did `#define inline __forceinline` on Windows. It rewrote `inline` on **data** declarations too, which MSVC rejects outright:

```
error C2433: '__forceinline' not permitted on data declarations
```

So no header reachable from `libhoard.cpp` could use a C++17 `inline` variable or a `static inline` member. That cost **three separate build breakages**, each of which compiled fine on macOS and Linux and blew up only on Windows CI, and each of which needed a hand-written out-of-class-definition workaround:

- the ownership bitmap (`ownershipmap.h`)
- the size-class tables (`sizeclasses.h`)
- the retain counter (`shardedglobalheap.h`)

## Why it's safe to drop

It was **legacy and redundant**:

- Heap-Layers already maps `INLINE` to `__forceinline` on MSVC — and has **its own copy of this `#define` commented out**.
- Every hot path force-inlines explicitly (`INLINE`, `TLAB_ALWAYS_INLINE`, or a bare `__forceinline`).
- `#pragma inline_depth(255)` stays.

Removing it lets headers use ordinary modern C++.

## Verified

macOS/Linux build clean and unchanged (recycle fast path 2.68 ns/op). Windows is the one that matters here — CI builds it and runs the full benchmark suite under DLL injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)