### PR TITLE
QoS gate: gate on Linux only, report (loudly) on macOS

### DIFF
--- a/.github/workflows/qos-larson.yml
+++ b/.github/workflows/qos-larson.yml
@@ -67,20 +67,30 @@ jobs:
 
       - name: Larson QoS gate
         run: |
-          # Floor for hoard/mimalloc, calibrated from measured runner variance
-          # (see the calibration note in scripts/qos_larson.py). Observed:
-          #   ubuntu  1t 0.84-0.90  4t 0.94-0.97
-          #   macos   1t 0.93-1.03  4t 0.96-1.12  (shared runners, ~0.1 swing)
-          # 0.75 sits clear of that noise and still trips on a ~17% regression.
-          # --retry-on-fail re-measures before failing, so a one-off dip from a
-          # noisy neighbour cannot break the build on its own.
+          # Only Linux GATES. Its hoard/mimalloc ratio measured 0.84-0.97 across
+          # repeated runs of unchanged code, so a 0.75 floor is clear of the
+          # noise and still trips on a ~17% regression.
+          #
+          # macOS is REPORT-ONLY. Its ratio measured 0.64-1.12 on unchanged code
+          # -- a master run read 0.64x with the runs either side reading ~1.0x,
+          # and a local A/B of those commits showed larson flat. The variation is
+          # BETWEEN runners, not within a job (that run's spread was only 6-16%),
+          # so --retry-on-fail cannot reject it either: the confirmation pass
+          # re-measures on the SAME runner. Any floor low enough to survive 0.64
+          # is too low to catch a real regression, so gating there would only
+          # train people to ignore a red check. See scripts/qos_larson.py.
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            GATE="--min-ratio 0.75 --retry-on-fail"
+          else
+            GATE="--report-only"
+          fi
           python3 scripts/qos_larson.py \
             --larson "$PWD/larson_bin" \
             --hoard "${{ steps.libs.outputs.hoard }}" \
             --mimalloc "${{ steps.libs.outputs.mimalloc }}" \
             --jemalloc "${{ steps.libs.outputs.jemalloc }}" \
             --threads 1,4 --reps 5 --sleep 3 \
-            --min-ratio 0.75 --retry-on-fail \
+            $GATE \
             ${{ inputs.report_only && '--report-only' || '' }} \
             --json qos-${{ matrix.os }}.json
 

--- a/scripts/qos_larson.py
+++ b/scripts/qos_larson.py
@@ -23,25 +23,31 @@ Interposition is VERIFIED, not assumed: a silently-not-preloaded library just
 measures the system allocator, which would make the gate meaningless (and on
 macOS, SIP strips DYLD_INSERT_LIBRARIES from system binaries -- see CLAUDE.md).
 
-CALIBRATING --min-ratio
------------------------
+CALIBRATING --min-ratio, AND WHY ONLY LINUX GATES
+-------------------------------------------------
 The floor is set from MEASURED runner variance, not guessed. Observed
-hoard/mimalloc across repeated CI runs (report-only, reps=5):
+hoard/mimalloc across repeated CI runs of UNCHANGED code:
 
-    ubuntu-latest (4 cpu, x86_64):  1t 0.84-0.90    4t 0.94-0.97
-    macos-latest  (3 cpu, arm64):   1t 0.93-1.03    4t 0.96-1.12
+    ubuntu-latest (4 cpu, x86_64):  0.84 - 0.97      <- tight, gateable
+    macos-latest  (3 cpu, arm64):   0.64 - 1.12      <- NOT gateable
 
-Linux is fairly tight. The macOS runners are shared and genuinely noisy: the
-RATIO itself swings by ~0.1 between runs, with up to 35% min-max spread within
-a single config. So the floor has to sit well below the worst observed value
-(0.84), which is why it is 0.75 rather than something snug like 0.80 -- a gate
-that flakes gets ignored, and an ignored gate is worse than none.
+Linux is tight, so it gates at 0.75: comfortably clear of its worst observed
+value (0.84) while still tripping on roughly a 17% regression (Hoard sits at
+~0.95-1.0x).
 
-On top of that, --retry-on-fail re-measures from scratch before failing, so a
-one-off noise dip has to happen twice independently to break the build. That is
-what buys the gate its sensitivity: it reliably catches a real regression
-(Hoard currently sits at ~0.9x mimalloc, so 0.75 trips on roughly a 17% drop)
-without failing on runner noise.
+macOS is REPORT-ONLY, and that is a deliberate concession. Its ratio spans 0.48
+on unchanged code -- a master run measured 0.64x and 0.69x while the run before
+and after it measured ~1.0x, and a local interleaved A/B of the same commits
+showed larson flat. The variation is BETWEEN runners, not within a job: the bad
+run's spread was only 6% (hoard) and 16% (mimalloc), so the numbers looked
+perfectly stable -- that runner was simply, consistently slow for Hoard.
+
+That also means --retry-on-fail cannot save it: the confirmation pass
+re-measures in the SAME job on the SAME runner, so it rejects a transient blip
+but not a runner that is degraded for its whole lifetime. Any floor low enough
+to survive 0.64 (i.e. below ~0.6) would be too low to catch a real regression,
+so gating there would only teach people to ignore a red check. We measure and
+print macOS instead, and gate on Linux.
 """
 
 import argparse
@@ -223,6 +229,21 @@ def main():
 
     print()
     if args.report_only:
+        # Report-only still has to be USEFUL: surface a bad ratio loudly so a
+        # real regression on this platform is noticed by a human, even though it
+        # cannot safely fail the build here.
+        low = [(c, r["hoard"]["median"] / r["mimalloc"]["median"])
+               for c, r in results.items()
+               if r["mimalloc"]["median"]
+               and r["hoard"]["median"] / r["mimalloc"]["median"] < 0.75]
+        if low:
+            print("::warning::larson below 0.75x mimalloc on " +
+                  ", ".join(f"{c} ({r:.2f}x)" for c, r in low) +
+                  " -- report-only on this platform (runner-to-runner variance "
+                  "is too large to gate on; see scripts/qos_larson.py). Compare "
+                  "the ABSOLUTE numbers above against another run before "
+                  "believing it: a slow runner drags Hoard down without "
+                  "necessarily moving the spread.")
         print("report-only: not gating.")
         return 0
     if failures:


### PR DESCRIPTION
Fixes the false positive the gate produced on master.

## What happened

The **#115 merge failed the gate on macOS** at 0.64x / 0.69x of mimalloc — while the master runs either side of it measured ~1.0x, and a local interleaved A/B of the same commits showed larson **flat**.

`--retry-on-fail` did not save it, and **could not**: the confirmation pass re-measures in the *same job on the same runner*. It rejects a transient blip, but not a runner that is degraded for its whole lifetime. And this wasn't visible noise — that run's spread was only **6%** (hoard) and **16%** (mimalloc). The runner was simply, consistently slow for Hoard.

## The numbers

`hoard/mimalloc` across repeated CI runs of **unchanged** code:

| runner | observed range |
|---|---|
| ubuntu-latest | **0.84 – 0.97** (tight) |
| macos-latest | **0.64 – 1.12** (spans 0.48) |

**No useful floor survives a 0.48 spread.** Anything low enough to tolerate 0.64 is too low to catch a real regression — and a gate that cries wolf just teaches people to ignore a red check, which is worse than having no gate at all.

## The fix

- **Linux gates** at 0.75 — clear of its worst observed 0.84, still trips on a ~17% regression.
- **macOS reports.** It measures and prints, and emits a `::warning::` if it dips below 0.75, so a genuine platform regression still reaches a human — with a note to compare the **absolute** numbers against another run first, since a slow runner drags Hoard down without necessarily moving the spread.

Verified both paths: Linux settings still PASS on a healthy tree (exit 0), and report-only emits the warning on a deliberately slow allocator without failing the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)