### PR TITLE
Capture Windows benchmark results: benchmarks write their own result file

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -327,6 +327,15 @@ jobs:
           # lock; ~10 minutes even in the last green master run).
           $timeouts = @{ "rptest" = 900 }
 
+          # BENCH_OUT: the benchmarks append their result line to this file
+          # themselves (see benchmarks/ci/bench_common.h). Their stdout is NOT
+          # reliably captured through withdll's DLL injection, so without this
+          # Windows could only ever see exit codes -- crash-tested, never
+          # performance-tested. A file the benchmark opens and fcloses itself
+          # does not depend on how the injected process inherited its handles.
+          $env:BENCH_OUT = "$PWD\hoard-results.txt"
+          if (Test-Path $env:BENCH_OUT) { Remove-Item $env:BENCH_OUT }
+
           $failed = @()
           foreach ($b in $benchmarks) {
             $name = $b[0]
@@ -337,6 +346,15 @@ jobs:
             if ($LASTEXITCODE -ne 0) {
               $failed += "$name (exit $LASTEXITCODE)"
             }
+          }
+
+          Write-Output ""
+          Write-Output "=== Hoard benchmark results (Windows) ==="
+          if (Test-Path $env:BENCH_OUT) {
+            Get-Content $env:BENCH_OUT | Tee-Object -FilePath hoard.txt -Append
+          } else {
+            Write-Error "No benchmark results captured -- BENCH_OUT file missing."
+            exit 1
           }
 
           if ($failed.Count -gt 0) {
@@ -371,6 +389,7 @@ jobs:
           path: |
             benchmarks/ci/build/Release/baseline.txt
             benchmarks/ci/build/Release/hoard.txt
+            benchmarks/ci/build/Release/hoard-results.txt
 
       - name: Upload hang diagnostics (stacks and dumps)
         if: always()

--- a/benchmarks/ci/alloc_test.c
+++ b/benchmarks/ci/alloc_test.c
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
   bench_thread_join_all(threads, nthreads);
 
   double elapsed = bench_timer_elapsed(&start);
-  printf("alloc-test: threads=%d allocs=%ld time=%.3f sec (%.0f ops/sec)\n",
+  bench_report("alloc-test: threads=%d allocs=%ld time=%.3f sec (%.0f ops/sec)\n",
          nthreads, total_allocs, elapsed, total_allocs / elapsed);
 
   free(threads);

--- a/benchmarks/ci/bench_common.h
+++ b/benchmarks/ci/bench_common.h
@@ -146,4 +146,39 @@ static inline unsigned int bench_rand(unsigned int* seed) {
   return (*seed >> 16) & 0x7fff;
 }
 
+/*
+ * Emit a benchmark's result line.
+ *
+ * Prints to stdout as usual, and ALSO appends to the file named by BENCH_OUT
+ * when that variable is set.
+ *
+ * Why: on Windows the benchmarks run under DLL injection (withdll.exe), and
+ * their stdout was not being captured -- CI could see exit codes but never a
+ * number, so Windows could be crash-tested and never performance-tested. A file
+ * we open, write and fclose ourselves does not depend on how the injected
+ * process inherited its standard handles, nor on the CRT flushing a buffer
+ * during teardown, so the result survives either way.
+ */
+#include <stdarg.h>
+
+static inline void bench_report(const char* fmt, ...) {
+  va_list ap;
+
+  va_start(ap, fmt);
+  vprintf(fmt, ap);
+  va_end(ap);
+  fflush(stdout);
+
+  const char* path = getenv("BENCH_OUT");
+  if (path != NULL && path[0] != '\0') {
+    FILE* f = fopen(path, "a");
+    if (f != NULL) {
+      va_start(ap, fmt);
+      vfprintf(f, fmt, ap);
+      va_end(ap);
+      fclose(f);            /* explicit: the line is on disk before we exit */
+    }
+  }
+}
+
 #endif /* BENCH_COMMON_H */

--- a/benchmarks/ci/cache_scratch.c
+++ b/benchmarks/ci/cache_scratch.c
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
 
   double elapsed = bench_timer_elapsed(&start);
   long total_ops = (long)nthreads * iterations;
-  printf("cache-scratch: threads=%d iterations=%d obj_size=%d time=%.3f sec (%.0f ops/sec)\n",
+  bench_report("cache-scratch: threads=%d iterations=%d obj_size=%d time=%.3f sec (%.0f ops/sec)\n",
          nthreads, iterations, obj_size, elapsed, total_ops / elapsed);
 
   free(threads);

--- a/benchmarks/ci/cache_thrash.c
+++ b/benchmarks/ci/cache_thrash.c
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
 
   double elapsed = bench_timer_elapsed(&start);
   long total_ops = (long)nthreads * iterations;
-  printf("cache-thrash: threads=%d iterations=%d obj_size=%d working_set=%d time=%.3f sec (%.0f ops/sec)\n",
+  bench_report("cache-thrash: threads=%d iterations=%d obj_size=%d working_set=%d time=%.3f sec (%.0f ops/sec)\n",
          nthreads, iterations, obj_size, working_set, elapsed, total_ops / elapsed);
 
   free(threads);

--- a/benchmarks/ci/cfrac.c
+++ b/benchmarks/ci/cfrac.c
@@ -29,7 +29,7 @@ int main(int argc, char** argv) {
   }
 
   double elapsed = bench_timer_elapsed(&start);
-  printf("cfrac: iterations=%d time=%.3f sec (%.0f ops/sec)\n",
+  bench_report("cfrac: iterations=%d time=%.3f sec (%.0f ops/sec)\n",
          iterations, elapsed, iterations / elapsed);
 
   return 0;

--- a/benchmarks/ci/larson.c
+++ b/benchmarks/ci/larson.c
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
   bench_thread_join_all(threads, nthreads);
 
   double elapsed = bench_timer_elapsed(&start);
-  printf("larson: threads=%d ops=%ld time=%.3f sec (%.0f ops/sec)\n",
+  bench_report("larson: threads=%d ops=%ld time=%.3f sec (%.0f ops/sec)\n",
          nthreads, total_ops, elapsed, total_ops / elapsed);
 
   /* Cleanup */

--- a/benchmarks/ci/malloc_large.c
+++ b/benchmarks/ci/malloc_large.c
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
   }
 
   double elapsed = bench_timer_elapsed(&start);
-  printf("malloc-large: iterations=%d time=%.3f sec (%.0f ops/sec)\n",
+  bench_report("malloc-large: iterations=%d time=%.3f sec (%.0f ops/sec)\n",
          iterations, elapsed, iterations / elapsed);
 
   return 0;

--- a/benchmarks/ci/mstress.c
+++ b/benchmarks/ci/mstress.c
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
   }
 
   double elapsed = bench_timer_elapsed(&start);
-  printf("mstress: threads=%d scale=%d iterations=%d allocs=%ld time=%.3f sec (%.0f ops/sec)\n",
+  bench_report("mstress: threads=%d scale=%d iterations=%d allocs=%ld time=%.3f sec (%.0f ops/sec)\n",
          nthreads, scale, iterations, total_allocs, elapsed, total_allocs / elapsed);
 
   /* Cleanup transfer array */

--- a/benchmarks/ci/rptest.c
+++ b/benchmarks/ci/rptest.c
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
   bench_thread_join_all(threads, nthreads);
 
   double elapsed = bench_timer_elapsed(&start);
-  printf("rptest: threads=%d loops=%d allocs_per_loop=%d total=%ld time=%.3f sec (%.0f ops/sec)\n",
+  bench_report("rptest: threads=%d loops=%d allocs_per_loop=%d total=%ld time=%.3f sec (%.0f ops/sec)\n",
          nthreads, loops, allocs_per_loop, total_allocs, elapsed, total_allocs / elapsed);
 
   free(threads);

--- a/benchmarks/ci/sh6bench.c
+++ b/benchmarks/ci/sh6bench.c
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
   }
 
   double elapsed = bench_timer_elapsed(&start);
-  printf("sh6bench: iterations=%d time=%.3f sec (%.0f ops/sec)\n",
+  bench_report("sh6bench: iterations=%d time=%.3f sec (%.0f ops/sec)\n",
          iterations, elapsed, iterations / elapsed);
 
   free(ptrs);

--- a/benchmarks/ci/sh8bench.c
+++ b/benchmarks/ci/sh8bench.c
@@ -118,7 +118,7 @@ int main(int argc, char** argv) {
   bench_thread_join_all(threads, nthreads);
 
   double elapsed = bench_timer_elapsed(&start);
-  printf("sh8bench: threads=%d ops=%ld time=%.3f sec (%.0f ops/sec)\n",
+  bench_report("sh8bench: threads=%d ops=%ld time=%.3f sec (%.0f ops/sec)\n",
          nthreads, total_ops, elapsed, total_ops / elapsed);
 
   /* Cleanup shared */

--- a/benchmarks/ci/xmalloc_test.c
+++ b/benchmarks/ci/xmalloc_test.c
@@ -119,7 +119,7 @@ int main(int argc, char** argv) {
   }
 
   double elapsed = bench_timer_elapsed(&start);
-  printf("xmalloc-test: producers=%d consumers=%d produced=%ld consumed=%ld time=%.3f sec\n",
+  bench_report("xmalloc-test: producers=%d consumers=%d produced=%ld consumed=%ld time=%.3f sec\n",
          num_producers, num_consumers, produced, consumed, elapsed);
 
   free(threads);


### PR DESCRIPTION
Windows CI could see **exit codes but never a number**.

## The problem

The benchmarks run under DLL injection (`withdll.exe`), and their stdout was not captured — `hoard.txt` held withdll's banner and nothing else. So Windows was **crash-tested but never performance-tested**, and a Windows performance regression would have gone completely unnoticed.

It's also why removing `#define inline __forceinline` (#117) couldn't be verified there: no number existed to look at.

## What I found

**alloc8#14** (merged) fixed the underlying handle bug: the Detours `withdll` sample launches the target with a **zeroed `STARTUPINFO`**, so it never sets `STARTF_USESTDHANDLES` and the target doesn't inherit a *redirected* stdout. That fix is correct and worth having on its own.

**But it wasn't sufficient** — with the fixed withdll in place, the benchmark output still didn't appear. Rather than keep bisecting a Windows-only path one slow CI cycle at a time, I made capture robust *by construction*.

## The fix

Each benchmark appends its own result line to the file named by `BENCH_OUT` (`bench_common.h`'s `bench_report`), opening and `fclose`-ing it itself:

```c
static inline void bench_report(const char* fmt, ...) {
  ...vprintf(fmt, ap); fflush(stdout);          /* stdout: unchanged */
  const char* path = getenv("BENCH_OUT");
  if (path) { FILE* f = fopen(path, "a"); vfprintf(f, fmt, ap); fclose(f); }
}
```

That depends on **neither** handle inheritance **nor** the CRT flushing a buffer during teardown, so the result survives either way.

- **stdout behaviour is unchanged** — Linux and macOS see exactly what they saw before (verified locally, with and without Hoard injected).
- The Windows job now prints the results **and fails loudly if the file is missing**, so silence can no longer masquerade as success.

## What this unlocks

Windows can now be performance-measured at all — which is the prerequisite for extending the QoS gate to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)