### PR TITLE
[EXPERIMENT — do not merge] measure forceinline define effect on Windows

### DIFF
--- a/src/source/libhoard.cpp
+++ b/src/source/libhoard.cpp
@@ -50,6 +50,10 @@
 // Maximize the degree of inlining.
 #pragma inline_depth(255)
 
+// EXPERIMENT (exp/reinstate-forceinline-define): temporarily re-add the macro
+// to measure whether it ever affected MSVC codegen. Revert before merge.
+#define inline __forceinline
+
 // NOTE: do NOT `#define inline __forceinline` here.
 //
 // It was legacy and redundant -- Heap-Layers already maps INLINE to


### PR DESCRIPTION
Throwaway A/B: re-adds `#define inline __forceinline` (removed in #117) to measure whether it affects the Windows QoS geomean. Master (without the define) sits at 1.44–1.65x the system heap. If this run is in that band, #117 is confirmed neutral. Will be closed unmerged.