### PR TITLE
[DIAG — do not merge] withdll stdout probe

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -297,12 +297,10 @@ jobs:
       - name: DIAG withdll stdout probe
         shell: powershell
         run: |
+          $ErrorActionPreference = "Continue"
           cd benchmarks/ci/build/Release
           $withdll = "$PWD/../../../../build/_deps/alloc8-build/Release/withdll.exe"
           $hoard = "$PWD/../../../../build/Release/hoard.dll"
-
-          Write-Output "=== is this our withdll? (source marker via /?) ==="
-          & $withdll /? 2>&1 | Out-String | Write-Output
 
           Write-Output "=== PROBE A: trivial grandchild (cmd echo) under withdll+Hoard ==="
           # Same redirection mechanism the watchdog uses (cmd > file).

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -294,6 +294,32 @@ jobs:
           "--- rptest ---" | Tee-Object -FilePath baseline.txt -Append
           .\rptest.exe 4 2>&1 | Tee-Object -FilePath baseline.txt -Append
 
+      - name: DIAG withdll stdout probe
+        shell: powershell
+        run: |
+          cd benchmarks/ci/build/Release
+          $withdll = "$PWD/../../../../build/_deps/alloc8-build/Release/withdll.exe"
+          $hoard = "$PWD/../../../../build/Release/hoard.dll"
+
+          Write-Output "=== is this our withdll? (source marker via /?) ==="
+          & $withdll /? 2>&1 | Out-String | Write-Output
+
+          Write-Output "=== PROBE A: trivial grandchild (cmd echo) under withdll+Hoard ==="
+          # Same redirection mechanism the watchdog uses (cmd > file).
+          cmd /c "`"$withdll`" /d:`"$hoard`" cmd /c `"echo PROBE_A_GRANDCHILD_STDOUT_OK`" > probeA.txt 2>&1"
+          Write-Output "  exit=$LASTEXITCODE ; probeA.txt:"
+          Get-Content probeA.txt | ForEach-Object { "    $_" }
+
+          Write-Output "=== PROBE B: larson under withdll+Hoard (the real case) ==="
+          cmd /c "`"$withdll`" /d:`"$hoard`" .\larson.exe 4 > probeB.txt 2>&1"
+          Write-Output "  exit=$LASTEXITCODE ; probeB.txt:"
+          Get-Content probeB.txt | ForEach-Object { "    $_" }
+
+          Write-Output "=== PROBE C: larson WITHOUT injection (baseline redirection) ==="
+          cmd /c ".\larson.exe 4 > probeC.txt 2>&1"
+          Write-Output "  exit=$LASTEXITCODE ; probeC.txt:"
+          Get-Content probeC.txt | ForEach-Object { "    $_" }
+
       - name: Run benchmarks with Hoard (watchdogged)
         shell: powershell
         # Each benchmark runs under a watchdog: on hang, all-thread stacks

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -318,6 +318,21 @@ jobs:
           Write-Output "  exit=$LASTEXITCODE ; probeC.txt:"
           Get-Content probeC.txt | ForEach-Object { "    $_" }
 
+          Write-Output "=== PROBE D: replicate the watchdog exactly (Start-Process -NoNewWindow on a .cmd) ==="
+          $script = "probeD.cmd"
+          @(
+            '@echo off',
+            "`"$withdll`" /d:`"$hoard`" cmd /c `"echo PROBE_D_GRANDCHILD_VIA_STARTPROCESS`" > probeD.txt 2> probeD.err.txt",
+            'exit /b %ERRORLEVEL%'
+          ) | Set-Content -Path $script -Encoding ASCII
+          $p = Start-Process -FilePath $env:ComSpec -ArgumentList @('/d','/c',$script) -NoNewWindow -PassThru
+          $null = $p.Handle
+          $p.WaitForExit()
+          Write-Output "  exit=$($p.ExitCode) ; probeD.txt:"
+          if (Test-Path probeD.txt) { Get-Content probeD.txt | ForEach-Object { "    $_" } }
+          Write-Output "  probeD.err.txt:"
+          if (Test-Path probeD.err.txt) { Get-Content probeD.err.txt | ForEach-Object { "    $_" } }
+
       - name: Run benchmarks with Hoard (watchdogged)
         shell: powershell
         # Each benchmark runs under a watchdog: on hang, all-thread stacks


### PR DESCRIPTION
Diagnostic to figure out why the injected process's stdout isn't captured through withdll. Probe A: trivial cmd-echo grandchild (isolates handle inheritance). Probe B: larson (real case). Probe C: larson without injection (control). Will be closed unmerged.